### PR TITLE
Add 1.21, add empty directory to avoid nil dereference crashes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ custom/
 ### Extensions
 
 Extensions serve a similar purpose as `custom/` patches, but are **not
-automatically applied**. However they are still part of the final artifact, but
+automatically applied**. However, they are still part of the final artifact, but
 need to added by the user themselves.
 
 Extensions can be applied as so:
@@ -66,5 +66,6 @@ Extensions can be applied as so:
 Current Patches:
 ```
 extensions/
+├── core                         # Placeholder for core extensions
 └── istio                        # Placeholder for istio CRD support
 ```

--- a/config.yml
+++ b/config.yml
@@ -41,3 +41,9 @@ specs:
   prefix: io.k8s.api.
   patchDir: custom/core
   extensionDir: extensions/core
+
+- output: '1.21'
+  openapi: https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.21/api/openapi-spec/swagger.json
+  prefix: io.k8s.api.
+  patchDir: custom/core
+  extensionDir: extensions/core


### PR DESCRIPTION
Cloning the repo as-is and running it causes a crash, since the extensions/core directory is not present.