### PR TITLE
fix(github-action): set gh-pages info in follow up step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@
 "jobs":
   "cert-manager":
     "name": "Generate cert-manager Jsonnet library and docs"
-    "needs": "terraform"
+    "needs": "repos"
     "runs-on": "ubuntu-latest"
     "steps":
     - "uses": "actions/checkout@v2"
@@ -15,7 +15,7 @@
     - "run": "make build libs/cert-manager"
   "cnrm":
     "name": "Generate cnrm Jsonnet library and docs"
-    "needs": "terraform"
+    "needs": "repos"
     "runs-on": "ubuntu-latest"
     "steps":
     - "uses": "actions/checkout@v2"
@@ -28,7 +28,7 @@
     - "run": "make build libs/cnrm"
   "crossplane":
     "name": "Generate crossplane Jsonnet library and docs"
-    "needs": "terraform"
+    "needs": "repos"
     "runs-on": "ubuntu-latest"
     "steps":
     - "uses": "actions/checkout@v2"
@@ -50,7 +50,7 @@
     - "run": "echo ${{ github.event_name }}"
   "istio":
     "name": "Generate istio Jsonnet library and docs"
-    "needs": "terraform"
+    "needs": "repos"
     "runs-on": "ubuntu-latest"
     "steps":
     - "uses": "actions/checkout@v2"
@@ -63,7 +63,7 @@
     - "run": "make build libs/istio"
   "k8s":
     "name": "Generate k8s Jsonnet library and docs"
-    "needs": "terraform"
+    "needs": "repos"
     "runs-on": "ubuntu-latest"
     "steps":
     - "uses": "actions/checkout@v2"
@@ -74,13 +74,50 @@
         chmod 600 ~/.ssh/id_rsa
         export GEN_COMMIT=1
     - "run": "make build libs/k8s"
-  "terraform":
+  "repos":
     "name": "create repositories"
     "runs-on": "ubuntu-latest"
     "steps":
     - "uses": "actions/checkout@v2"
     - "uses": "zendesk/setup-jsonnet@v7"
-    - "run": "make tf/main.tf.json"
+    - "env":
+        "PAGES": "false"
+      "run": "make tf/main.tf.json"
+    - "uses": "hashicorp/setup-terraform@v1"
+      "with":
+        "cli_config_credentials_token": "${{ secrets.TF_API_TOKEN }}"
+    - "env":
+        "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
+        "TF_IN_AUTOMATION": "1"
+      "run": "terraform init"
+      "working-directory": "tf"
+    - "env":
+        "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
+        "TF_IN_AUTOMATION": "1"
+      "run": "terraform validate -no-color"
+      "working-directory": "tf"
+    - "env":
+        "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
+        "TF_IN_AUTOMATION": "1"
+      "if": "${{ github.ref != 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+      "run": "terraform plan -no-color"
+      "working-directory": "tf"
+    - "env":
+        "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
+        "TF_IN_AUTOMATION": "1"
+      "if": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+      "run": "terraform apply -no-color -auto-approve"
+      "working-directory": "tf"
+  "repos_with_pages":
+    "name": "create repositories"
+    "needs": "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v2"
+    - "uses": "zendesk/setup-jsonnet@v7"
+    - "env":
+        "PAGES": "true"
+      "run": "make tf/main.tf.json"
     - "uses": "hashicorp/setup-terraform@v1"
       "with":
         "cli_config_credentials_token": "${{ secrets.TF_API_TOKEN }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@
         export GEN_COMMIT=1
     - "run": "make build libs/k8s"
   "repos":
-    "name": "create repositories"
+    "name": "Create repositories"
     "runs-on": "ubuntu-latest"
     "steps":
     - "uses": "actions/checkout@v2"
@@ -109,8 +109,8 @@
       "run": "terraform apply -no-color -auto-approve"
       "working-directory": "tf"
   "repos_with_pages":
-    "name": "create repositories"
-    "needs": "repos"
+    "name": "Set up gh-pages branch"
+    "needs": "jobs"
     "runs-on": "ubuntu-latest"
     "steps":
     - "uses": "actions/checkout@v2"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,23 +87,23 @@
       "with":
         "cli_config_credentials_token": "${{ secrets.TF_API_TOKEN }}"
     - "env":
-        "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
+        "GITHUB_TOKEN": "${{ secrets.PAT }}"
         "TF_IN_AUTOMATION": "1"
       "run": "terraform init"
       "working-directory": "tf"
     - "env":
-        "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
+        "GITHUB_TOKEN": "${{ secrets.PAT }}"
         "TF_IN_AUTOMATION": "1"
       "run": "terraform validate -no-color"
       "working-directory": "tf"
     - "env":
-        "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
+        "GITHUB_TOKEN": "${{ secrets.PAT }}"
         "TF_IN_AUTOMATION": "1"
       "if": "${{ github.ref != 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
       "run": "terraform plan -no-color"
       "working-directory": "tf"
     - "env":
-        "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
+        "GITHUB_TOKEN": "${{ secrets.PAT }}"
         "TF_IN_AUTOMATION": "1"
       "if": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
       "run": "terraform apply -no-color -auto-approve"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,12 @@
       "working-directory": "tf"
   "repos_with_pages":
     "name": "Set up gh-pages branch"
-    "needs": "jobs"
+    "needs":
+    - "istio"
+    - "crossplane"
+    - "k8s"
+    - "cnrm"
+    - "cert-manager"
     "runs-on": "ubuntu-latest"
     "steps":
     - "uses": "actions/checkout@v2"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ OUTPUT_DIR ?= ${PWD}/gen
 ABS_OUTPUT_DIR := $(shell realpath $(OUTPUT_DIR))
 
 IMPORTS=$(shell find libs -name config.jsonnet | xargs -I {} echo "(import '{}'),")
-PAGES := true
+PAGES := false
 
 .DEFAULT_GOAL: default
 default:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ OUTPUT_DIR ?= ${PWD}/gen
 ABS_OUTPUT_DIR := $(shell realpath $(OUTPUT_DIR))
 
 IMPORTS=$(shell find libs -name config.jsonnet | xargs -I {} echo "(import '{}'),")
+PAGES := true
 
 .DEFAULT_GOAL: default
 default:
@@ -18,7 +19,7 @@ default:
 ## Requires go-jsonnet for -c flag
 .PHONY: tf/main.tf.json
 tf/main.tf.json:
-	jsonnet -c -m . -S -J . --tla-code "libs=[$(IMPORTS)]" jsonnet/terraform.jsonnet
+	jsonnet -c -m . -S -J . --tla-code "pages=$(PAGES)" --tla-code "libs=[$(IMPORTS)]" jsonnet/terraform.jsonnet
 
 clean:
 	rm -f .github/workflows/main.yml:

--- a/jsonnet/github_action.jsonnet
+++ b/jsonnet/github_action.jsonnet
@@ -34,9 +34,9 @@ local terraform = {
       self.tf_env + onMaster { run: 'terraform apply -no-color -auto-approve' },
     ],
   },
-  withPages: {
+  withPages(needs): {
     name: 'Set up gh-pages branch',
-    needs: 'jobs',
+    needs: needs,
     make_env+:: {
       env+: {
         PAGES: 'true',
@@ -84,7 +84,7 @@ function(libs) {
           ],
         },
         repos: terraform.job,
-        repos_with_pages: terraform.job + terraform.withPages,
+        repos_with_pages: terraform.job + terraform.withPages([lib.name for lib in libs]),
       },
     }),
 }

--- a/jsonnet/github_action.jsonnet
+++ b/jsonnet/github_action.jsonnet
@@ -14,7 +14,7 @@ local terraform = {
         TF_IN_AUTOMATION: '1',
       },
     },
-    name: 'create repositories',
+    name: 'Create repositories',
     'runs-on': 'ubuntu-latest',
     steps: [
       { uses: 'actions/checkout@v2' },
@@ -35,7 +35,8 @@ local terraform = {
     ],
   },
   withPages: {
-    needs: 'repos',
+    name: 'Set up gh-pages branch',
+    needs: 'jobs',
     make_env+:: {
       env+: {
         PAGES: 'true',

--- a/jsonnet/terraform.jsonnet
+++ b/jsonnet/terraform.jsonnet
@@ -1,4 +1,4 @@
-function(libs, pages=true) {
+function(libs, pages=false) {
   'tf/main.tf.json':
     std.manifestJsonEx(
       {
@@ -28,14 +28,6 @@ function(libs, pages=true) {
           acc {
             resource+:
               [{
-                github_repository_deploy_key: {
-                  [lib.name]: {
-                    title: 'jsonnet-libs/k8s deploy key',
-                    repository: '${github_repository.' + lib.name + '.name}',
-                    key: importstr './files/id_rsa.pub',
-                    read_only: false,
-                  },
-                },
                 github_repository: {
                   [lib.name]: {
                     name: lib.name + lib.suffix,

--- a/jsonnet/terraform.jsonnet
+++ b/jsonnet/terraform.jsonnet
@@ -33,6 +33,7 @@ function(libs, pages=false) {
                     name: lib.name + lib.suffix,
                     description: lib.description,
                     homepage_url: lib.site_url,
+                    topics: ['jsonnet', 'jsonnet-libs'],
                     auto_init: true,
                     has_downloads: false,
                     has_issues: false,

--- a/jsonnet/terraform.jsonnet
+++ b/jsonnet/terraform.jsonnet
@@ -40,9 +40,15 @@ function(libs, pages=false) {
                     has_wiki: false,
                     allow_merge_commit: false,
                     allow_rebase_merge: false,
+                    lifecycle: {
+                      ignore_changes: ['pages'],
+                    },
                   } + (
                     if pages
                     then {
+                      lifecycle: {
+                        ignore_changes: [],
+                      },
                       pages:
                         {
                           source:

--- a/jsonnet/terraform.jsonnet
+++ b/jsonnet/terraform.jsonnet
@@ -1,4 +1,4 @@
-function(libs) {
+function(libs, pages=true) {
   'tf/main.tf.json':
     std.manifestJsonEx(
       {
@@ -48,15 +48,20 @@ function(libs) {
                     has_wiki: false,
                     allow_merge_commit: false,
                     allow_rebase_merge: false,
-                    pages:
-                      {
-                        source:
-                          {
-                            branch: 'gh-pages',
-                            path: '/',
-                          },
-                      },
-                  },
+                  } + (
+                    if pages
+                    then {
+                      pages:
+                        {
+                          source:
+                            {
+                              branch: 'gh-pages',
+                              path: '/',
+                            },
+                        },
+                    }
+                    else {}
+                  ),
                 },
               }],
           },

--- a/scripts/gen.sh
+++ b/scripts/gen.sh
@@ -17,6 +17,10 @@ if [ -z "${GEN_COMMIT}" ]; then
     mkdir -p "${OUTPUT_DIR}"
 else
     git clone --depth 1 "ssh://git@${REPO}" "${OUTPUT_DIR}"
+    set +eo pipefail
+    # Create the gh-pages branch if it doesn't exist.
+    git push origin gh-pages || (git branch -c gh-pages && git push origin gh-pages)
+    set -eo pipefail
 fi
 
 # Remove everything except .git


### PR DESCRIPTION
This is a workaround for a bootstrapping problem.

The Github pages configuration can't be applied if the branch does not exist yet. Possible
future solution: https://github.com/integrations/terraform-provider-github/issues/782