### PR TITLE
fix: jb install branch name + improved search

### DIFF
--- a/libs/k8s/README_root.md.tmpl
+++ b/libs/k8s/README_root.md.tmpl
@@ -17,7 +17,7 @@ For more info, refer to the Tanka tutorial at https://tanka.dev/tutorial/k-lib.
 #### Standalone
 
 ```bash
-$ jb install github.com/jsonnet-libs/k8s-libsonnet/%(version)s
+$ jb install github.com/jsonnet-libs/k8s-libsonnet/%(version)s@main
 ```
 
 Then import it in your project:

--- a/libs/k8s/config.jsonnet
+++ b/libs/k8s/config.jsonnet
@@ -27,6 +27,17 @@ config.new(
 )
 + {
 
+  mkdocs_config+: {
+    plugins+: [{
+      'exclude-search': {
+        exclude: [
+          version + '/*'
+          for version in versions[1:]
+        ],
+      },
+    }],
+  },
+
   'skel/README.md': (importstr './README_root.md.tmpl') % {
     version: versions[0],
   },


### PR DESCRIPTION
- k8s-libsonnet uses the main branch, `jb` defaults to master
- this PR will limit the search to the latest version, hopefully making the search more
  deterministic