### PR TITLE
Bump crossplane versions and fix reserved function keyword

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,13 +119,13 @@
   "repos_with_pages":
     "name": "Set up gh-pages branch"
     "needs":
-    - "kube-prometheus"
-    - "istio"
-    - "crossplane"
     - "strimzi"
-    - "k8s"
-    - "cnrm"
+    - "kube-prometheus"
     - "cert-manager"
+    - "cnrm"
+    - "crossplane"
+    - "k8s"
+    - "istio"
     "runs-on": "ubuntu-latest"
     "steps":
     - "uses": "actions/checkout@v2"

--- a/libs/crossplane/config.jsonnet
+++ b/libs/crossplane/config.jsonnet
@@ -4,11 +4,25 @@ config.new(
   name='crossplane',
   specs=[
     {
+      output: 'crossplane/1.3',
+      openapi: 'http://localhost:8001/openapi/v2',
+      prefix: '^io\\.crossplane\\.(pkg|apiextensions)\\..*',
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane/crossplane@v1.3.0'],
+      localName: 'crossplane',
+    },
+    {
       output: 'crossplane/1.2',
       openapi: 'http://localhost:8001/openapi/v2',
       prefix: '^io\\.crossplane\\.(pkg|apiextensions)\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/crossplane/crossplane@v1.2.1'],
       localName: 'crossplane',
+    },
+    {
+      output: 'provider-aws/0.19',
+      openapi: 'http://localhost:8001/openapi/v2',
+      prefix: '^io\\.crossplane\\.aws\\..*',
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane/provider-aws@v0.19.0'],
+      localName: 'crossplane_aws',
     },
     {
       output: 'provider-aws/0.18',

--- a/pkg/builder/objects.go
+++ b/pkg/builder/objects.go
@@ -42,7 +42,7 @@ func Object(name string, children ...Type) ObjectType {
 
 func escapeKey(s string) string {
 	switch s {
-	case "local", "error":
+	case "local", "error", "function":
 		return fmt.Sprintf(`'%s'`, s)
 	default:
 		if strings.HasPrefix(s, "-") {

--- a/pkg/model/modifiers.go
+++ b/pkg/model/modifiers.go
@@ -109,6 +109,9 @@ func fnArg(name string) string {
 	if name == "local" {
 		return "Local"
 	}
+	if name == "function" {
+		return "Function"
+	}
 	if strings.HasPrefix(name, "-") {
 		return strings.TrimPrefix(name, "-")
 	}


### PR DESCRIPTION
Adds support for `crossplane 1.3` and `provider-aws 0.19`.

In addition, adds support for Jsonnet reserved `function` keyword (conflicts with AWS Lamba which would break rendering of package).