### PR TITLE
Include resource kinds that are not under the standard regex path.

### DIFF
--- a/libs/k8s/config.jsonnet
+++ b/libs/k8s/config.jsonnet
@@ -16,7 +16,7 @@ config.new(
     {
       output: version,
       openapi: 'https://raw.githubusercontent.com/kubernetes/kubernetes/release-' + version + '/api/openapi-spec/swagger.json',
-      prefix: '^io\\.k8s\\.api\\..*',
+      prefix: '^io\\.k8s\\.(api|kube-aggregator\\.pkg\\.apis)\\..*',
       patchDir: 'custom/core',
       extensionsDir: 'extensions/core',
       localName: 'k',


### PR DESCRIPTION
Specifically `APIService` kinds are scoped under the `io.k8s.kube-aggregator.pkg.apis.*` path.
