### PR TITLE
fix: add more reserved names to token escaping

### DIFF
--- a/pkg/builder/objects.go
+++ b/pkg/builder/objects.go
@@ -42,10 +42,10 @@ func Object(name string, children ...Type) ObjectType {
 
 func escapeKey(s string) string {
 	switch s {
-	case "local", "error", "function":
+	case "local", "error", "function", "import":
 		return fmt.Sprintf(`'%s'`, s)
 	default:
-		if strings.HasPrefix(s, "-") {
+		if strings.Contains(s, "-") {
 			return fmt.Sprintf(`'%s'`, s)
 		}
 		if strings.HasPrefix(s, "#") {

--- a/pkg/model/modifiers.go
+++ b/pkg/model/modifiers.go
@@ -116,6 +116,9 @@ func fnArg(name string) string {
 	if name == "function" {
 		return "Function"
 	}
+	if name == "import" {
+		return "Import"
+	}
 	if strings.HasPrefix(name, "-") {
 		return strings.TrimPrefix(name, "-")
 	}


### PR DESCRIPTION
This adds import as a reserved keyword and widens the `-` restriction to contains instead of prefix.

With these changes, the generator can successfully generate jsonnet bindings for OpenShift 4