### PR TITLE
Generate full library for `argo-workflows`

### DIFF
--- a/jsonnet/terraform.jsonnet
+++ b/jsonnet/terraform.jsonnet
@@ -7,7 +7,7 @@ function(libs, pages=false) {
           required_providers: {
             github: {
               source: 'integrations/github',
-              version: '~>4.0',
+              version: '~>4.14.0',
             },
           },
           backend: {

--- a/libs/argo-workflows/config.jsonnet
+++ b/libs/argo-workflows/config.jsonnet
@@ -6,14 +6,7 @@ config.new(
     {
       output: '3.1',
       prefix: '^io\\.argoproj\\..*',
-      crds: [
-        // Full manifests are broken: https://github.com/argoproj/argo-workflows/issues/6588
-        'https://raw.githubusercontent.com/argoproj/argo-workflows/v3.1.8/manifests/base/crds/minimal/argoproj.io_clusterworkflowtemplates.yaml',
-        'https://raw.githubusercontent.com/argoproj/argo-workflows/v3.1.8/manifests/base/crds/minimal/argoproj.io_cronworkflows.yaml',
-        'https://raw.githubusercontent.com/argoproj/argo-workflows/v3.1.8/manifests/base/crds/minimal/argoproj.io_workfloweventbindings.yaml',
-        'https://raw.githubusercontent.com/argoproj/argo-workflows/v3.1.8/manifests/base/crds/minimal/argoproj.io_workflows.yaml',
-        'https://raw.githubusercontent.com/argoproj/argo-workflows/v3.1.8/manifests/base/crds/minimal/argoproj.io_workflowtemplates.yaml',
-      ],
+      openapi: 'https://raw.githubusercontent.com/argoproj/argo-workflows/v3.1.12/api/jsonschema/schema.json',
       localName: 'argo_workflows',
     },
   ]


### PR DESCRIPTION
Turns out that there's already a full json schema in the argo-workflows repo: https://github.com/argoproj/argo-workflows/blob/master/api/jsonschema/schema.json
No need to do the k3s stuff