### PR TITLE
Support recursive references

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@
     "steps":
     - "uses": "actions/checkout@v2"
     - "env":
+        "DIFF": "true"
         "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
         "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
@@ -19,6 +20,7 @@
     "steps":
     - "uses": "actions/checkout@v2"
     - "env":
+        "DIFF": "true"
         "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
         "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
@@ -31,6 +33,7 @@
     "steps":
     - "uses": "actions/checkout@v2"
     - "env":
+        "DIFF": "true"
         "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
         "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
@@ -43,6 +46,7 @@
     "steps":
     - "uses": "actions/checkout@v2"
     - "env":
+        "DIFF": "true"
         "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
         "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
@@ -55,6 +59,7 @@
     "steps":
     - "uses": "actions/checkout@v2"
     - "env":
+        "DIFF": "true"
         "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
         "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
@@ -77,6 +82,7 @@
     "steps":
     - "uses": "actions/checkout@v2"
     - "env":
+        "DIFF": "true"
         "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
         "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
@@ -89,6 +95,7 @@
     "steps":
     - "uses": "actions/checkout@v2"
     - "env":
+        "DIFF": "true"
         "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
         "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
@@ -101,6 +108,7 @@
     "steps":
     - "uses": "actions/checkout@v2"
     - "env":
+        "DIFF": "true"
         "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
         "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
@@ -113,6 +121,7 @@
     "steps":
     - "uses": "actions/checkout@v2"
     - "env":
+        "DIFF": "true"
         "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
         "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
@@ -125,6 +134,7 @@
     "steps":
     - "uses": "actions/checkout@v2"
     - "env":
+        "DIFF": "true"
         "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
         "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
@@ -217,6 +227,7 @@
     "steps":
     - "uses": "actions/checkout@v2"
     - "env":
+        "DIFF": "true"
         "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
         "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ FROM alpine:3.14
 
 WORKDIR /app
 
-RUN apk add --no-cache bash curl git openssh
+RUN apk add --no-cache bash curl git openssh diffutils
 
 ENV KUBECONFIG=/app/kubeconfig/kube-config.yaml
 RUN chmod a+w /app

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ libs/*:
 	./bin/docker.sh \
 		-v $(shell realpath $@):/config \
 		-v $(ABS_OUTPUT_DIR):/output \
+		-e DIFF \
 		-e GEN_COMMIT="$(GEN_COMMIT)" \
 		-e GITHUB_SHA="$(GITHUB_SHA)" \
 		-e GIT_AUTHOR_NAME="$(GIT_AUTHOR_NAME)" \

--- a/jsonnet/github_action.jsonnet
+++ b/jsonnet/github_action.jsonnet
@@ -59,6 +59,7 @@ local libJob(name) = {
         GIT_COMMITTER_EMAIL: '86770550+jsonnet-libs-bot@users.noreply.github.com',
         SSH_KEY: '${{ secrets.DEPLOY_KEY }}',
         GEN_COMMIT: "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}",
+        DIFF: 'true',
       },
     },
   ],

--- a/libs/argo-workflows/config.jsonnet
+++ b/libs/argo-workflows/config.jsonnet
@@ -9,5 +9,12 @@ config.new(
       openapi: 'https://raw.githubusercontent.com/argoproj/argo-workflows/v3.1.12/api/jsonschema/schema.json',
       localName: 'argo_workflows',
     },
+    {
+      output: '3.2',
+      prefix: '^io\\.argoproj\\..*',
+      // TODO: Use 3.2.0 tag once it's released
+      openapi: 'https://raw.githubusercontent.com/argoproj/argo-workflows/master/api/jsonschema/schema.json',
+      localName: 'argo_workflows',
+    },
   ]
 )

--- a/scripts/gen.sh
+++ b/scripts/gen.sh
@@ -131,3 +131,13 @@ else
     fi
     popd
 fi
+
+
+if [ "${DIFF}" == "true" ]; then
+    echo "Diffing..."
+    DIFF_DIR="${TMPDIR:-/tmp/}${REPO}"
+    # HTTPS should always be usable without creds
+    git clone --depth 1 "https://${REPO}" "${DIFF_DIR}"
+
+    (diff -r --exclude .git "${DIFF_DIR}" "${OUTPUT_DIR}" && echo "No diff!") || echo "There's a diff!"
+fi


### PR DESCRIPTION
While testing a change I made to the argo-workflows jsonschema, I found this:
argo-workflows introduces a  definition which is recursive which makes the `make libs/argo-workflows` command die from stack overflow

- This PR adds a resolve map that saves the *Schema objects so that they are reused instead of being resolved infinitely. 
- To test this, I added a way to diff libraries after generating them. I added that to CI. It doesn't fail the build when there's a diff but you can look at it manually

Submitting this for early review, I will merge this once Argo Workflows 3.2.0 is released