### PR TITLE
Add consul-k8s

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,18 @@
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
       "run": "make build libs/cnrm"
+  "consul-k8s":
+    "name": "Generate consul-k8s Jsonnet library and docs"
+    "needs": "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v2"
+    - "env":
+        "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+        "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
+        "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
+        "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
+      "run": "make build libs/consul-k8s"
   "crossplane":
     "name": "Generate crossplane Jsonnet library and docs"
     "needs": "repos"
@@ -206,6 +218,7 @@
     - "calico"
     - "cert-manager"
     - "cnrm"
+    - "consul-k8s"
     - "crossplane"
     - "eck-operator"
     - "flagger"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,18 +52,19 @@
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
       "run": "make build libs/cnrm"
-  "consul-k8s":
-    "name": "Generate consul-k8s Jsonnet library and docs"
+  "consul":
+    "name": "Generate consul Jsonnet library and docs"
     "needs": "repos"
     "runs-on": "ubuntu-latest"
     "steps":
     - "uses": "actions/checkout@v2"
     - "env":
+        "DIFF": "true"
         "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
         "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
-      "run": "make build libs/consul-k8s"
+      "run": "make build libs/consul"
   "crossplane":
     "name": "Generate crossplane Jsonnet library and docs"
     "needs": "repos"
@@ -118,6 +119,7 @@
     "steps":
     - "uses": "actions/checkout@v2"
     - "env":
+        "DIFF": "true"
         "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
         "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
@@ -218,7 +220,7 @@
     - "calico"
     - "cert-manager"
     - "cnrm"
-    - "consul-k8s"
+    - "consul"
     - "crossplane"
     - "eck-operator"
     - "flagger"

--- a/libs/consul-k8s/config.jsonnet
+++ b/libs/consul-k8s/config.jsonnet
@@ -1,0 +1,27 @@
+local config = import 'jsonnet/config.jsonnet';
+
+local versions = ['0.34.1'];
+
+config.new(
+  name='consul-k8s',
+  specs=[
+    {
+      local url = 'https://raw.githubusercontent.com/hashicorp/consul-k8s/v%s/control-plane/config/crd/bases' % version,
+      output: version,
+      prefix: '^com\\.hashicorp\\.consul\\..*',
+      crds: [
+        '%s/consul.hashicorp.com_ingressgateways.yaml' % url,
+        '%s/consul.hashicorp.com_servicedefaults.yaml' % url,
+        '%s/consul.hashicorp.com_servicerouters.yaml' % url,
+        '%s/consul.hashicorp.com_meshes.yaml' % url,
+        '%s/consul.hashicorp.com_serviceintentions.yaml' % url,
+        '%s/consul.hashicorp.com_servicesplitters.yaml' % url,
+        '%s/consul.hashicorp.com_proxydefaults.yaml' % url,
+        '%s/consul.hashicorp.com_serviceresolvers.yaml' % url,
+        '%s/consul.hashicorp.com_terminatinggateways.yaml' % url,
+      ],
+      localName: 'consul-k8s',
+    }
+    for version in versions
+  ]
+)

--- a/libs/consul/config.jsonnet
+++ b/libs/consul/config.jsonnet
@@ -3,7 +3,7 @@ local config = import 'jsonnet/config.jsonnet';
 local versions = ['0.34.1'];
 
 config.new(
-  name='consul-k8s',
+  name='consul',
   specs=[
     {
       local url = 'https://raw.githubusercontent.com/hashicorp/consul-k8s/v%s/control-plane/config/crd/bases' % version,
@@ -20,7 +20,7 @@ config.new(
         '%s/consul.hashicorp.com_serviceresolvers.yaml' % url,
         '%s/consul.hashicorp.com_terminatinggateways.yaml' % url,
       ],
-      localName: 'consul-k8s',
+      localName: 'consul',
     }
     for version in versions
   ]

--- a/libs/consul/config.jsonnet
+++ b/libs/consul/config.jsonnet
@@ -1,13 +1,15 @@
 local config = import 'jsonnet/config.jsonnet';
 
-local versions = ['0.34.1'];
+local versions = [
+  {output: '0.34', version:'0.34.1'}
+];
 
 config.new(
   name='consul',
   specs=[
     {
-      local url = 'https://raw.githubusercontent.com/hashicorp/consul-k8s/v%s/control-plane/config/crd/bases' % version,
-      output: version,
+      local url = 'https://raw.githubusercontent.com/hashicorp/consul-k8s/v%s/control-plane/config/crd/bases' % v.version,
+      output: v.output,
       prefix: '^com\\.hashicorp\\.consul\\..*',
       crds: [
         '%s/consul.hashicorp.com_ingressgateways.yaml' % url,
@@ -22,6 +24,6 @@ config.new(
       ],
       localName: 'consul',
     }
-    for version in versions
+    for v in versions
   ]
 )


### PR DESCRIPTION
Split on whether to name this just `consul` or `consul-k8s`

Hashicorp seem to be consolidating all of the their Kubernetes related 'stuff' into the consul-k8s repo so I've gone with that too