### PR TITLE
feat: add Kubernetes 1.23 & remove legacy versions

### DIFF
--- a/libs/k8s/config.jsonnet
+++ b/libs/k8s/config.jsonnet
@@ -1,14 +1,11 @@
 local config = import 'jsonnet/config.jsonnet';
 local versions = [
+  '1.23',
   '1.22',
   '1.21',
   '1.20',
   '1.19',
   '1.18',
-  '1.17',
-  '1.16',
-  '1.15',
-  '1.14',
 ];
 
 config.new(


### PR DESCRIPTION
Right now the oldest supported release on Public Clouds is 1.18 (AWS) -> cleanup the older releases

Signed-off-by: Matthias Riegler <matthias.riegler@traefik.io>