### PR TITLE
feat/openshift support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@
     - "uses": "actions/checkout@v2"
     - "env":
         "DIFF": "true"
+
         "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
         "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
@@ -177,6 +178,19 @@
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
       "run": "make build libs/k8s"
+  "openshift":
+    "name": "Generate openshift Jsonnet library and docs"
+    "needs": "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v2"
+    - "env":
+        "DIFF": "true"
+        "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+        "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
+        "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
+        "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
+      "run": "make build libs/openshift"
   "kube-prometheus":
     "name": "Generate kube-prometheus Jsonnet library and docs"
     "needs": "repos"
@@ -255,6 +269,7 @@
     - "grafana-agent"
     - "istio"
     - "k8s"
+    - "openshift"
     - "kube-prometheus"
     - "rabbitmq"
     - "strimzi"

--- a/libs/openshift/config.jsonnet
+++ b/libs/openshift/config.jsonnet
@@ -1,0 +1,24 @@
+local config = import 'jsonnet/config.jsonnet';
+local versions = [
+  '3.11',
+  '4.0',
+  '4.1',
+  '4.2',
+  '4.3',
+  '4.4',
+  '4.5',
+];
+
+config.new(
+  name='openshift',
+  specs=[
+    {
+      output: version,
+      openapi: 'https://raw.githubusercontent.com/openshift/origin/release-'+version+'/api/swagger-spec/openshift-openapi-spec.json',
+      prefix: '^com\\.github\\.openshift\\.api\\..*',
+      localName: 'o',
+      description: 'Generated Jsonnet library for OpenShift v' + version,
+    }
+    for version in versions
+  ]
+)

--- a/pkg/model/modifiers.go
+++ b/pkg/model/modifiers.go
@@ -82,7 +82,7 @@ func newModifier(name string, p *swagger.Schema, ctx string) (string, interface{
 	name = CamelLower(name)
 
 	switch p.Type {
-	case swagger.TypeObject:
+	case swagger.TypeObject, "":
 		// if it has children, return modifier group instead
 		if len(p.Props) != 0 {
 			o := Object{

--- a/pkg/swagger/swagger.go
+++ b/pkg/swagger/swagger.go
@@ -148,6 +148,23 @@ func (s Schema) GroupVersionKind() (*XGvk, bool) {
 		return nil, false
 	}
 
-	x := s.XGvk[0]
-	return &x, true
+	// sometimes multiple XGVKs exist for the same schema. In this case we want to
+	// select the most specific one.
+	var x *XGvk
+	for _, g := range s.XGvk {
+		if x == nil || (x.Group == "" && g.Group != "") {
+			x = &g
+		}
+		if x.Version == "" && g.Version != "" {
+			x = &g
+		}
+		if x.Kind == "" && g.Kind != "" {
+			x = &g
+		}
+	}
+	// safeguard against malformed schemas with completely empty XGVKs
+	if x == nil {
+		return nil, false
+	}
+	return x, true
 }


### PR DESCRIPTION
This adds initial support for OpenShift version 3.11 -> 4.5. Later versions are currently not released as swagger files, which complicates generation.

One change required to make this possible was to use the most specific GVK instead of the first one.


It is still not completely usable now as the generated objects are missing the `metadata` property. I would greatly appreciate hints in that regard