### PR TITLE
Add Cluster API + AWS Provider templates, improve applying CRDs on generation step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,32 @@
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
       "run": "make build libs/cert-manager"
+  "cluster-api":
+    "name": "Generate cluster-api Jsonnet library and docs"
+    "needs": "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v2"
+    - "env":
+        "DIFF": "true"
+        "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+        "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
+        "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
+        "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
+      "run": "make build libs/cluster-api"
+  "cluster-api-provider-aws":
+    "name": "Generate cluster-api-provider-aws Jsonnet library and docs"
+    "needs": "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v2"
+    - "env":
+        "DIFF": "true"
+        "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+        "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
+        "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
+        "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
+      "run": "make build libs/cluster-api-provider-aws"
   "cnrm":
     "name": "Generate cnrm Jsonnet library and docs"
     "needs": "repos"
@@ -112,6 +138,19 @@
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
       "run": "make build libs/eck-operator"
+  "external-secrets":
+    "name": "Generate external-secrets Jsonnet library and docs"
+    "needs": "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v2"
+    - "env":
+        "DIFF": "true"
+        "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+        "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
+        "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
+        "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
+      "run": "make build libs/external-secrets"
   "flagger":
     "name": "Generate flagger Jsonnet library and docs"
     "needs": "repos"
@@ -246,10 +285,13 @@
     - "argo-workflows"
     - "calico"
     - "cert-manager"
+    - "cluster-api"
+    - "cluster-api-provider-aws"
     - "cnrm"
     - "consul"
     - "crossplane"
     - "eck-operator"
+    - "external-secrets"
     - "flagger"
     - "fluxcd"
     - "grafana-agent"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ config.new(
       prefix: '^<prefix>\\.<name>\\..*',
 
       # crds Endpoints of the CRD manifests, should be omitted if there is an openapi spec
+      # Only resources of kind CustomResourceDefintion are applied; the default policy is to just
+      # pass in the CRDs here though.
       crds: ['https://url.to.crd.manifest/<version>/manifests/crd-all.gen.yaml'],
 
       # localName used in the docs for the example(s)

--- a/libs/cluster-api-provider-aws/config.jsonnet
+++ b/libs/cluster-api-provider-aws/config.jsonnet
@@ -1,0 +1,14 @@
+local config = import 'jsonnet/config.jsonnet';
+
+config.new(
+  name='cluster-api-provider-aws',
+  specs=[
+    {
+      output: 'v1.2.0',
+      openapi: 'http://localhost:8001/openapi/v2',
+      prefix: '^io\\.x-k8s\\.cluster\\..*',
+      crds: ['https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/download/v1.2.0/infrastructure-components.yaml'],
+      localName: 'cluster-api-provider-aws',
+    },
+  ]
+)

--- a/libs/cluster-api/config.jsonnet
+++ b/libs/cluster-api/config.jsonnet
@@ -1,0 +1,14 @@
+local config = import 'jsonnet/config.jsonnet';
+
+config.new(
+  name='cluster-api',
+  specs=[
+    {
+      output: 'v1.0.2',
+      openapi: 'http://localhost:8001/openapi/v2',
+      prefix: '^io\\.x-k8s\\.cluster\\..*',
+      crds: ['https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.2/core-components.yaml'],
+      localName: 'cluster-api',
+    },
+  ]
+)

--- a/scripts/gen.sh
+++ b/scripts/gen.sh
@@ -75,7 +75,10 @@ for SPEC in ${SPECS}; do
         exit 1
         fi
 
-        kubectl apply -f "${CRDFILE}"
+        # Only apply CRDs, some projects don't publish CRDs independent but as part of an "install bundle"
+        cat ${CRDFILE} \
+          | yq2 e 'select(.kind == "CustomResourceDefinition")' - \
+          | kubectl apply -f -
 
         kubectl proxy --port=${PROXY_PORT} &
 


### PR DESCRIPTION
This adds jsonnet libraries for:
- [cluster-api](https://github.com/kubernetes-sigs/cluster-api)
- [cluster-api-provider-aws](https://github.com/kubernetes-sigs/cluster-api-provider-aws)

In addition it filters the provided manifests (CRDs) to only apply CRDs to the cluster.