### PR TITLE
fix(ci): master build is failing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ WORKDIR /app
 
 RUN apk add --no-cache bash curl git openssh diffutils
 
+ENV KUBECONFIG=/app/kubeconfig/kube-config.yaml
+RUN chmod a+w /app
+
 RUN chmod a+w /tmp
 
 COPY --from=mikefarah/yq:4.9.6 /usr/bin/yq /usr/local/bin/yq2

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,7 @@ WORKDIR /app
 
 RUN apk add --no-cache bash curl git openssh diffutils
 
-ENV KUBECONFIG=/app/kubeconfig/kube-config.yaml
-RUN chmod a+w /app
+RUN chmod a+w /tmp
 
 COPY --from=mikefarah/yq:4.9.6 /usr/bin/yq /usr/local/bin/yq2
 COPY --from=bitnami/kubectl:1.21.2 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/

--- a/libs/crossplane/config.jsonnet
+++ b/libs/crossplane/config.jsonnet
@@ -16,45 +16,9 @@ config.new(
       localName: 'crossplane',
     },
     {
-      output: 'crossplane/1.3',
-      prefix: '^io\\.crossplane\\.(pkg|apiextensions)\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/crossplane@v1.3.1'],
-      localName: 'crossplane',
-    },
-    {
-      output: 'crossplane/1.2',
-      prefix: '^io\\.crossplane\\.(pkg|apiextensions)\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/crossplane@v1.2.1'],
-      localName: 'crossplane',
-    },
-    {
       output: 'provider-aws/0.23',
       prefix: '^io\\.crossplane\\.aws\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/crossplane/provider-aws@v0.23.0'],
-      localName: 'crossplane_aws',
-    },
-    {
-      output: 'provider-aws/0.22',
-      prefix: '^io\\.crossplane\\.aws\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/provider-aws@v0.22.0'],
-      localName: 'crossplane_aws',
-    },
-    {
-      output: 'provider-aws/0.20',
-      prefix: '^io\\.crossplane\\.aws\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/provider-aws@v0.20.0'],
-      localName: 'crossplane_aws',
-    },
-    {
-      output: 'provider-aws/0.19',
-      prefix: '^io\\.crossplane\\.aws\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/provider-aws@v0.19.0'],
-      localName: 'crossplane_aws',
-    },
-    {
-      output: 'provider-aws/0.18',
-      prefix: '^io\\.crossplane\\.aws\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/provider-aws@v0.18.1'],
       localName: 'crossplane_aws',
     },
     {
@@ -64,45 +28,15 @@ config.new(
       localName: 'crossplane_gcp',
     },
     {
-      output: 'provider-gcp/0.18',
-      prefix: '^io\\.crossplane\\.gcp\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/provider-gcp@v0.18.0'],
-      localName: 'crossplane_gcp',
-    },
-    {
-      output: 'provider-gcp/0.17',
-      prefix: '^io\\.crossplane\\.gcp\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/provider-gcp@v0.17.0'],
-      localName: 'crossplane_gcp',
-    },
-    {
       output: 'provider-azure/0.18',
       prefix: '^io\\.crossplane\\.azure\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/crossplane/provider-azure@v0.18.1'],
       localName: 'crossplane_azure',
     },
     {
-      output: 'provider-azure/0.17',
-      prefix: '^io\\.crossplane\\.azure\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/provider-azure@v0.17.0'],
-      localName: 'crossplane_azure',
-    },
-    {
-      output: 'provider-azure/0.16',
-      prefix: '^io\\.crossplane\\.azure\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/provider-azure@v0.16.1'],
-      localName: 'crossplane_azure',
-    },
-    {
       output: 'provider-sql/0.3',
       prefix: '^io\\.crossplane\\.sql\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-sql@v0.3.0'],
-      localName: 'crossplane_sql',
-    },
-    {
-      output: 'provider-sql/0.2',
-      prefix: '^io\\.crossplane\\.sql\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-sql@v0.2.0'],
       localName: 'crossplane_sql',
     },
     {


### PR DESCRIPTION
This PR reduces the number of crossplane libs being rendered to only the latest minor
version.

It also fixes the Dockerfile so a local render of a library works again, mktemp was
failing as the local users did not have write permission.