### PR TITLE
Add zalando-postgres-operator v1.6 and v1.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -328,6 +328,7 @@
     - "openshift"
     - "rabbitmq"
     - "strimzi"
+    - "zalando-postgres-operator"
     "runs-on": "ubuntu-latest"
     "steps":
     - "uses": "actions/checkout@v2"
@@ -375,6 +376,19 @@
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
       "run": "make build libs/strimzi"
+  "zalando-postgres-operator":
+    "name": "Generate zalando-postgres-operator Jsonnet library and docs"
+    "needs": "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v2"
+    - "env":
+        "DIFF": "true"
+        "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+        "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
+        "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
+        "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
+      "run": "make build libs/zalando-postgres-operator"
 "on":
   "pull_request":
     "branches":

--- a/libs/zalando-postgres-operator/config.jsonnet
+++ b/libs/zalando-postgres-operator/config.jsonnet
@@ -1,0 +1,22 @@
+local config = import 'jsonnet/config.jsonnet';
+local versions = [
+  {version: '1.7', tag: 'v1.7.1' },
+  {version: '1.6', tag: 'v1.6.3' },
+];
+
+config.new(
+  name='zalando-postgres-operator',
+  specs=[
+    {
+      output: v.version,
+      prefix: '^do\\.zalan\\.acid\\..*',
+      crds: [
+        'https://github.com/zalando/postgres-operator/raw/'+v.tag+'/charts/postgres-operator/crds/operatorconfigurations.yaml',
+        'https://github.com/zalando/postgres-operator/raw/'+v.tag+'/charts/postgres-operator/crds/postgresqls.yaml',
+        'https://github.com/zalando/postgres-operator/raw/'+v.tag+'/charts/postgres-operator/crds/postgresteams.yaml',
+      ],
+      localName: 'zalando_postgres_operator',
+    }
+    for v in versions
+  ]
+)


### PR DESCRIPTION
The CRDs are taken from the tag with the highest patch version for each
minor version. Versions older than v1.6 use the older deprecated v1beta1
CRDs and have some CRDS missing or at different places in the repo and
have therefore been omitted for simplicity
