### PR TITLE
Fix null as key escaping

### DIFF
--- a/pkg/builder/objects.go
+++ b/pkg/builder/objects.go
@@ -42,7 +42,7 @@ func Object(name string, children ...Type) ObjectType {
 
 func escapeKey(s string) string {
 	switch s {
-	case "local", "error", "function", "import":
+	case "local", "error", "function", "import", "null":
 		return fmt.Sprintf(`'%s'`, s)
 	default:
 		if strings.HasPrefix(s, "#") {

--- a/pkg/model/modifiers.go
+++ b/pkg/model/modifiers.go
@@ -119,6 +119,9 @@ func fnArg(name string) string {
 	if name == "import" {
 		return "Import"
 	}
+	if name == "null" {
+		return "Null"
+	}
 	if strings.HasPrefix(name, "-") {
 		return strings.TrimPrefix(name, "-")
 	}


### PR DESCRIPTION
Before this change, it was not possible to generate libraries that had a
valid "null" OpenAPI key in their CRD.

We fix this by escaping correctly the reserved word 'null'.

There are no tests in this PR, please advise on how to correctly add them.

Fixes #116 