### PR TITLE
chore: update libs

### DIFF
--- a/libs/calico/config.jsonnet
+++ b/libs/calico/config.jsonnet
@@ -1,15 +1,23 @@
 local config = import 'jsonnet/config.jsonnet';
 
-local versions = [
+local legacy_versions = [
   ['3.15', '3.15.5'],
   ['3.16', '3.16.10'],
   ['3.17', '3.17.6'],
   ['3.18', '3.18.6'],
   ['3.19', '3.19.4'],
   ['3.20', '3.20.4'],
+];
+
+local legacy_path = 'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/';
+
+local versions = [
   ['3.21', '3.21.4'],
   ['3.22', '3.22.0'],
 ];
+
+// The files in new versions were moved here:
+local path = 'https://raw.githubusercontent.com/projectcalico/calico/v%s/libcalico-go/config/crd/';
 
 config.new(
   name='calico',
@@ -18,26 +26,52 @@ config.new(
       output: version[0],
       prefix: '^org\\.projectcalico\\.crd\\..*',
       crds: [
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_bgpconfigurations.yaml' % version[1],
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_bgppeers.yaml' % version[1],
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_blockaffinities.yaml' % version[1],
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_clusterinformations.yaml' % version[1],
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_felixconfigurations.yaml' % version[1],
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_globalnetworkpolicies.yaml' % version[1],
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_globalnetworksets.yaml' % version[1],
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_hostendpoints.yaml' % version[1],
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_ipamblocks.yaml' % version[1],
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_ipamconfigs.yaml' % version[1],
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_ipamhandles.yaml' % version[1],
+        (path % version[1]) + 'crd.projectcalico.org_bgpconfigurations.yaml',
+        (path % version[1]) + 'crd.projectcalico.org_bgppeers.yaml',
+        (path % version[1]) + 'crd.projectcalico.org_blockaffinities.yaml',
+        (path % version[1]) + 'crd.projectcalico.org_clusterinformations.yaml',
+        (path % version[1]) + 'crd.projectcalico.org_felixconfigurations.yaml',
+        (path % version[1]) + 'crd.projectcalico.org_globalnetworkpolicies.yaml',
+        (path % version[1]) + 'crd.projectcalico.org_globalnetworksets.yaml',
+        (path % version[1]) + 'crd.projectcalico.org_hostendpoints.yaml',
+        (path % version[1]) + 'crd.projectcalico.org_ipamblocks.yaml',
+        (path % version[1]) + 'crd.projectcalico.org_ipamconfigs.yaml',
+        (path % version[1]) + 'crd.projectcalico.org_ipamhandles.yaml',
         // IPPools resource is currently not included because the CRD breaks jsonnet by having a `-` within the deprecated key name `nat-outgoing`.
         // Once this has been removed, this file can be included and the comment removed.
-        // 'https://raw.githubusercontent.com/projectcalico/calico/v%s.0/_includes/charts/calico/crds/kdd/crd.projectcalico.org_ippools.yaml' % version[1],
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_kubecontrollersconfigurations.yaml' % version[1],
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_networkpolicies.yaml' % version[1],
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_networksets.yaml' % version[1],
+        // (path % version[1]) + 'crd.projectcalico.org_ippools.yaml',
+        (path % version[1]) + 'crd.projectcalico.org_kubecontrollersconfigurations.yaml',
+        (path % version[1]) + 'crd.projectcalico.org_networkpolicies.yaml',
+        (path % version[1]) + 'crd.projectcalico.org_networksets.yaml',
       ],
       localName: 'calico',
     }
     for version in versions
+  ] + [
+    {
+      output: version[0],
+      prefix: '^org\\.projectcalico\\.crd\\..*',
+      crds: [
+        (legacy_path % version[1]) + 'crd.projectcalico.org_bgpconfigurations.yaml',
+        (legacy_path % version[1]) + 'crd.projectcalico.org_bgppeers.yaml',
+        (legacy_path % version[1]) + 'crd.projectcalico.org_blockaffinities.yaml',
+        (legacy_path % version[1]) + 'crd.projectcalico.org_clusterinformations.yaml',
+        (legacy_path % version[1]) + 'crd.projectcalico.org_felixconfigurations.yaml',
+        (legacy_path % version[1]) + 'crd.projectcalico.org_globalnetworkpolicies.yaml',
+        (legacy_path % version[1]) + 'crd.projectcalico.org_globalnetworksets.yaml',
+        (legacy_path % version[1]) + 'crd.projectcalico.org_hostendpoints.yaml',
+        (legacy_path % version[1]) + 'crd.projectcalico.org_ipamblocks.yaml',
+        (legacy_path % version[1]) + 'crd.projectcalico.org_ipamconfigs.yaml',
+        (legacy_path % version[1]) + 'crd.projectcalico.org_ipamhandles.yaml',
+        // IPPools resource is currently not included because the CRD breaks jsonnet by having a `-` within the deprecated key name `nat-outgoing`.
+        // Once this has been removed, this file can be included and the comment removed.
+        // (legacy_path % version[1]) + 'crd.projectcalico.org_ippools.yaml',
+        (legacy_path % version[1]) + 'crd.projectcalico.org_kubecontrollersconfigurations.yaml',
+        (legacy_path % version[1]) + 'crd.projectcalico.org_networkpolicies.yaml',
+        (legacy_path % version[1]) + 'crd.projectcalico.org_networksets.yaml',
+      ],
+      localName: 'calico',
+    }
+    for version in legacy_versions
   ]
 )

--- a/libs/calico/config.jsonnet
+++ b/libs/calico/config.jsonnet
@@ -1,31 +1,40 @@
 local config = import 'jsonnet/config.jsonnet';
 
-local versions = ['3.15','3.16','3.17','3.18','3.19','3.20'];
+local versions = [
+  ['3.15', '3.15.5'],
+  ['3.16', '3.16.10'],
+  ['3.17', '3.17.6'],
+  ['3.18', '3.18.6'],
+  ['3.19', '3.19.4'],
+  ['3.20', '3.20.4'],
+  ['3.21', '3.21.4'],
+  ['3.22', '3.22.0'],
+];
 
 config.new(
   name='calico',
   specs=[
     {
-      output: version,
+      output: version[0],
       prefix: '^org\\.projectcalico\\.crd\\..*',
       crds: [
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s.0/_includes/charts/calico/crds/kdd/crd.projectcalico.org_bgpconfigurations.yaml' % version,
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s.0/_includes/charts/calico/crds/kdd/crd.projectcalico.org_bgppeers.yaml' % version,
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s.0/_includes/charts/calico/crds/kdd/crd.projectcalico.org_blockaffinities.yaml' % version,
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s.0/_includes/charts/calico/crds/kdd/crd.projectcalico.org_clusterinformations.yaml' % version,
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s.0/_includes/charts/calico/crds/kdd/crd.projectcalico.org_felixconfigurations.yaml' % version,
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s.0/_includes/charts/calico/crds/kdd/crd.projectcalico.org_globalnetworkpolicies.yaml' % version,
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s.0/_includes/charts/calico/crds/kdd/crd.projectcalico.org_globalnetworksets.yaml' % version,
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s.0/_includes/charts/calico/crds/kdd/crd.projectcalico.org_hostendpoints.yaml' % version,
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s.0/_includes/charts/calico/crds/kdd/crd.projectcalico.org_ipamblocks.yaml' % version,
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s.0/_includes/charts/calico/crds/kdd/crd.projectcalico.org_ipamconfigs.yaml' % version,
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s.0/_includes/charts/calico/crds/kdd/crd.projectcalico.org_ipamhandles.yaml' % version,
+        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_bgpconfigurations.yaml' % version[1],
+        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_bgppeers.yaml' % version[1],
+        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_blockaffinities.yaml' % version[1],
+        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_clusterinformations.yaml' % version[1],
+        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_felixconfigurations.yaml' % version[1],
+        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_globalnetworkpolicies.yaml' % version[1],
+        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_globalnetworksets.yaml' % version[1],
+        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_hostendpoints.yaml' % version[1],
+        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_ipamblocks.yaml' % version[1],
+        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_ipamconfigs.yaml' % version[1],
+        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_ipamhandles.yaml' % version[1],
         // IPPools resource is currently not included because the CRD breaks jsonnet by having a `-` within the deprecated key name `nat-outgoing`.
         // Once this has been removed, this file can be included and the comment removed.
-        // 'https://raw.githubusercontent.com/projectcalico/calico/v%s.0/_includes/charts/calico/crds/kdd/crd.projectcalico.org_ippools.yaml' % version,
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s.0/_includes/charts/calico/crds/kdd/crd.projectcalico.org_kubecontrollersconfigurations.yaml' % version,
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s.0/_includes/charts/calico/crds/kdd/crd.projectcalico.org_networkpolicies.yaml' % version,
-        'https://raw.githubusercontent.com/projectcalico/calico/v%s.0/_includes/charts/calico/crds/kdd/crd.projectcalico.org_networksets.yaml' % version,
+        // 'https://raw.githubusercontent.com/projectcalico/calico/v%s.0/_includes/charts/calico/crds/kdd/crd.projectcalico.org_ippools.yaml' % version[1],
+        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_kubecontrollersconfigurations.yaml' % version[1],
+        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_networkpolicies.yaml' % version[1],
+        'https://raw.githubusercontent.com/projectcalico/calico/v%s/_includes/charts/calico/crds/kdd/crd.projectcalico.org_networksets.yaml' % version[1],
       ],
       localName: 'calico',
     }

--- a/libs/cnrm/config.jsonnet
+++ b/libs/cnrm/config.jsonnet
@@ -4,7 +4,7 @@ config.new(
   name='cnrm',
   specs=[
     {
-      output: '1.33',
+      output: '1.74',
       prefix: '^com\\.google\\.cloud\\.cnrm\\..*',
       crds: ['https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-config-connector/v1.74.0/install-bundles/install-bundle-workload-identity/crds.yaml'],
       localName: 'cnrm',

--- a/libs/cnrm/config.jsonnet
+++ b/libs/cnrm/config.jsonnet
@@ -6,7 +6,7 @@ config.new(
     {
       output: '1.33',
       prefix: '^com\\.google\\.cloud\\.cnrm\\..*',
-      crds: ['https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-config-connector/1.33.0/install-bundles/install-bundle-workload-identity/crds.yaml'],
+      crds: ['https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-config-connector/v1.74.0/install-bundles/install-bundle-workload-identity/crds.yaml'],
       localName: 'cnrm',
     },
   ],

--- a/libs/istio/config.jsonnet
+++ b/libs/istio/config.jsonnet
@@ -1,20 +1,18 @@
 local config = import 'jsonnet/config.jsonnet';
 local versions = [
-  '1.11',
-  '1.10',
-  '1.9',
-  '1.8',
-  '1.7',
-  '1.6'
+  ['1.13', '1.13.0'],
+  ['1.12', '1.12.3'],
+  ['1.11', '1.11.6'],
+  ['1.10', '1.10.6'],
 ];
 
 config.new(
   name='istio',
   specs=[
     {
-      output: version,
+      output: version[0],
       prefix: '^io\\.istio\\..*',
-      crds: ['https://raw.githubusercontent.com/istio/istio/' + version + '.1' + '/manifests/charts/base/crds/crd-all.gen.yaml'],
+      crds: ['https://raw.githubusercontent.com/istio/istio/' + version[1] + '/manifests/charts/base/crds/crd-all.gen.yaml'],
       localName: 'istio',
     }
     for version in versions


### PR DESCRIPTION
Separate lib updates from #119 to verify diff.

These libs had CRDs based on the deprecated `apiextensions.k8s.io/v1beta1`. The calico
also had a minor issue with a duplicate field that was resolved in a patch, also the CRDs in new versions got moved.