### PR TITLE
k8s-libsonnet: include apimachinery meta structures

### DIFF
--- a/libs/k8s/config.jsonnet
+++ b/libs/k8s/config.jsonnet
@@ -14,7 +14,7 @@ config.new(
     {
       output: version,
       openapi: 'https://raw.githubusercontent.com/kubernetes/kubernetes/release-' + version + '/api/openapi-spec/swagger.json',
-      prefix: '^io\\.k8s\\.(api|kube-aggregator\\.pkg\\.apis)\\..*',
+      prefix: '^io\\.k8s\\.(api|(kube-aggregator|apimachinery)\\.pkg\\.apis)\\..*',
       patchDir: 'custom/core',
       extensionsDir: 'extensions/core',
       localName: 'k',


### PR DESCRIPTION
The previous group selector excluded the meta structures which are contained under "io.k8s.apimachinery.pkg.apis.meta". As a result, some very widely used substructures (e.g. labelSelector #124 ) were not included in the libsonnet output. 

P.S.: I couldn't find the "kube-aggregator" group in the current swagger.json, is that still used?
