### PR TITLE
feat(crossplane): Add helm-provider and  bump multiple versions

### DIFF
--- a/libs/crossplane/config.jsonnet
+++ b/libs/crossplane/config.jsonnet
@@ -4,9 +4,15 @@ config.new(
   name='crossplane',
   specs=[
     {
+      output: 'crossplane/1.7',
+      prefix: '^io\\.crossplane\\.(pkg|apiextensions)\\..*',
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane/crossplane@v1.7.0'],
+      localName: 'crossplane',
+    },
+    {
       output: 'crossplane/1.6',
       prefix: '^io\\.crossplane\\.(pkg|apiextensions)\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/crossplane@v1.6.3'],
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane/crossplane@v1.6.4'],
       localName: 'crossplane',
     },
     {
@@ -46,9 +52,9 @@ config.new(
       localName: 'crossplane_sql',
     },
     {
-      output: 'provider-kubernetes/0.2',
+      output: 'provider-kubernetes/0.3',
       prefix: '^io\\.crossplane\\.kubernetes\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-kubernetes@v0.2.0'],
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-kubernetes@v0.3.0'],
       localName: 'crossplane_kubernetes',
     },
     {

--- a/libs/crossplane/config.jsonnet
+++ b/libs/crossplane/config.jsonnet
@@ -63,5 +63,11 @@ config.new(
       crds: ['https://doc.crds.dev/raw/github.com/grafana/crossplane-provider-grafana@v0.0.9'],
       localName: 'crossplane_grafana',
     },
+    {
+      output: 'provider-helm/10.0',
+      prefix: '^io\\.crossplane\\.helm\\..*',
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-helm@v0.10.0'],
+      localName: 'crossplane_helm',
+    },
   ]
 )


### PR DESCRIPTION
- Add crossplane 1.7 from release 1.7.0
- Bump crossplane 1.6 to release 1.6.4
- Bump provider-kubernetes to release 0.3
