### PR TITLE
fix(crossplane/grafana): include providerConfig

### DIFF
--- a/libs/crossplane/config.jsonnet
+++ b/libs/crossplane/config.jsonnet
@@ -59,7 +59,7 @@ config.new(
     },
     {
       output: 'provider-grafana/0.0',
-      prefix: '^io\\.crossplane\\.jet\\.grafana\\.grafana\\..*',
+      prefix: '^io\\.crossplane\\.jet\\.grafana\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/grafana/crossplane-provider-grafana@v0.0.9'],
       localName: 'crossplane_grafana',
     },


### PR DESCRIPTION
The nested 'grafana.grafana' doesn't include the providerConfig, I'll probably propose upstream to eventually drop the repeated nesting.