### PR TITLE
chore(crossplane/provider-helm): Fix typo in published version

### DIFF
--- a/libs/crossplane/config.jsonnet
+++ b/libs/crossplane/config.jsonnet
@@ -64,7 +64,7 @@ config.new(
       localName: 'crossplane_grafana',
     },
     {
-      output: 'provider-helm/10.0',
+      output: 'provider-helm/0.10',
       prefix: '^io\\.crossplane\\.helm\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-helm@v0.10.0'],
       localName: 'crossplane_helm',


### PR DESCRIPTION
The recently added helm-provider for crossplane was added in version
0.10, however the output-path was incorrectly set to version "10.0".
This commit corrects that oversight
