### PR TITLE
added contour to generated libs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,6 +211,26 @@
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
       "run": "make libs/consul"
+  "contour":
+    "name": "Generate contour Jsonnet library and docs"
+    "needs":
+    - "build"
+    - "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v2"
+    - "uses": "actions/download-artifact@v2"
+      "with":
+        "name": "docker-artifact"
+        "path": "artifacts"
+    - "run": "make load"
+    - "env":
+        "DIFF": "true"
+        "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+        "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
+        "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
+        "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
+      "run": "make libs/contour"
   "crossplane":
     "name": "Generate crossplane Jsonnet library and docs"
     "needs":
@@ -528,6 +548,7 @@
     - "cnrm"
     - "composable"
     - "consul"
+    - "contour"
     - "crossplane"
     - "eck-operator"
     - "external-secrets"

--- a/libs/contour/config.jsonnet
+++ b/libs/contour/config.jsonnet
@@ -1,0 +1,28 @@
+local config = import 'jsonnet/config.jsonnet';
+local versions = [
+  { version: '1.20', tag: 'v1.20.1'},
+  { version: '1.19', tag: 'v1.19.1'},
+  { version: '1.18', tag: 'v1.18.3'},
+  { version: '1.17', tag: 'v1.17.2'},
+  { version: '1.16', tag: 'v1.16.1'},
+  { version: '1.15', tag: 'v1.15.2'},
+  { version: '1.14', tag: 'v1.14.2'},
+  { version: '1.13', tag: 'v1.13.1'},
+  { version: '1.12', tag: 'v1.12.0'},
+  { version: '1.11', tag: 'v1.11.0'},
+  { version: '1.10', tag: 'v1.10.1'},
+  { version: '1.9', tag: 'v1.9.0'},
+];
+
+config.new(
+  name='contour',
+  specs=[
+    {
+      output: v.version,
+      prefix: '^io\\.projectcontour\\..*',
+      crds: ['https://raw.githubusercontent.com/projectcontour/contour/%(tag)s/examples/contour/01-crds.yaml' % v],
+      localName: 'contour',
+    }
+    for v in versions
+  ]
+)


### PR DESCRIPTION
## Added Contour to generated libraries.

I feel that [Project contour](https://projectcontour.io/) is an important CNCF member which deserves to be included in `jsonnet-libs` collection of generated libraries.


>NOTE: I could not generate versions prior to `1.9.0`,  as the generator crashes with the following error:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x95e582]

goroutine 1 [running]:
github.com/jsonnet-libs/k8s/pkg/swagger.(*CRDLoader).Load(0x7f19ef591418, {0xc00052c000, 0xc0006bc330, 0x1})
        /app/pkg/swagger/crd.go:52 +0x582
github.com/jsonnet-libs/k8s/pkg/swagger.Load({0xb2b540, 0xc00000e0d8}, {0xc000074840, 0x1})
        /app/pkg/swagger/load.go:23 +0x90
main.main.func1(0xc0000694c0, {0xc00002cd00, 0x0, 0x4})
        /app/main.go:62 +0x554
github.com/go-clix/cli.(*Command).execute(0xc0001b0e60, {0xc00001e0b0, 0x4, 0x4})
        /go/pkg/mod/github.com/go-clix/cli@v0.1.2-0.20200502172020-b8f4629e879a/command.go:120 +0x32f
github.com/go-clix/cli.(*Command).Execute(0xc0001b0e60)
        /go/pkg/mod/github.com/go-clix/cli@v0.1.2-0.20200502172020-b8f4629e879a/command.go:76 +0xda
main.main()
        /app/main.go:88 +0x1ad
make: *** [libs/contour] Error 2
```