### PR TITLE
Update cert-manager

### DIFF
--- a/libs/cert-manager/config.jsonnet
+++ b/libs/cert-manager/config.jsonnet
@@ -1,8 +1,8 @@
 local config = import 'jsonnet/config.jsonnet';
 local versions = [
   { version: '1.8', tag: 'v1.8.0'},
-  { version: '1.7', tag: 'v1.7.1'},
-  { version: '1.6', tag: 'v1.6.2'},
+  { version: '1.7', tag: 'v1.7.2'},
+  { version: '1.6', tag: 'v1.6.3'},
   { version: '1.5', tag: 'v1.5.5'},
   { version: '1.4', tag: 'v1.4.4'},
   { version: '1.3', tag: 'v1.3.3'},

--- a/libs/cert-manager/config.jsonnet
+++ b/libs/cert-manager/config.jsonnet
@@ -1,5 +1,6 @@
 local config = import 'jsonnet/config.jsonnet';
 local versions = [
+  { version: '1.8', tag: 'v1.8.0'},
   { version: '1.7', tag: 'v1.7.1'},
   { version: '1.6', tag: 'v1.6.2'},
   { version: '1.5', tag: 'v1.5.5'},


### PR DESCRIPTION
Version 1.8 of cert-manager is out, and there are also some new patch versions of prior releases.