### PR TITLE
Remove k8s-libsonnet extensions patch in >= 1.22

### DIFF
--- a/libs/k8s/custom/core/apps.libsonnet
+++ b/libs/k8s/custom/core/apps.libsonnet
@@ -1,4 +1,5 @@
 local d = import 'doc-util/main.libsonnet';
+local gen = import '../gen.libsonnet';
 
 local patch = {
   daemonSet+: {
@@ -72,8 +73,8 @@ local patch = {
 };
 
 {
-  extensions+: {  // old, remove asap
-    v1beta1+: patch,
+  [if std.objectHas(gen, 'extensions') then 'extensions']+: { // This was removed in v1.22
+    [if std.objectHas(gen.extensions, 'v1beta1') then 'v1beta1']+: patch,
   },
   apps+: {
     v1+: patch,


### PR DESCRIPTION
The extensions/v1beta1 API was removed in Kubernetes v1.22. The patch
that adds documentation for that API shouldn't be applied if the API
doesn't exist.

Fixes #132.