### PR TITLE
Add version 3.3 of Argo Workflows

### DIFF
--- a/libs/argo-workflows/config.jsonnet
+++ b/libs/argo-workflows/config.jsonnet
@@ -1,19 +1,19 @@
 local config = import 'jsonnet/config.jsonnet';
+local versions = [
+  { version: '3.1', tag: 'v3.1.12' },
+  { version: '3.2', tag: 'v3.2.2' },
+  { version: '3.3', tag: 'v3.3.3' },
+];
 
 config.new(
   name='argo-workflows',
   specs=[
     {
-      output: '3.1',
+      output: v.version,
       prefix: '^io\\.argoproj\\..*',
-      openapi: 'https://raw.githubusercontent.com/argoproj/argo-workflows/v3.1.12/api/jsonschema/schema.json',
+      openapi: 'https://raw.githubusercontent.com/argoproj/argo-workflows/%s/api/jsonschema/schema.json' % v.tag,
       localName: 'argo_workflows',
-    },
-    {
-      output: '3.2',
-      prefix: '^io\\.argoproj\\..*',
-      openapi: 'https://raw.githubusercontent.com/argoproj/argo-workflows/v3.2.2/api/jsonschema/schema.json',
-      localName: 'argo_workflows',
-    },
+    }
+    for v in versions
   ]
 )


### PR DESCRIPTION
This additionally contains a minor refactor to reduce duplication in the jsonnet
for Argo Workflows to allow easier addition of versions in future.