### PR TITLE
fix(crossplane): set writeConnectionSecretRef when adding connectionDetails

### DIFF
--- a/libs/crossplane/custom/crossplane/resource.libsonnet
+++ b/libs/crossplane/custom/crossplane/resource.libsonnet
@@ -66,11 +66,14 @@ local d = import 'doc-util/main.libsonnet';
         d.arg('namespace', d.T.string),
         d.arg('connectionDetails', d.T.array),
       ]),
-      withConnectionDetailsMixin(namespace, connectionDetails)::
-        self.withConnectionSecretMixin(self.name, namespace)
-        + {
-          connectionDetails+: connectionDetails,
-        },
+      withConnectionDetailsMixin(namespace, connectionDetails):: {
+        local resource = super.resource,
+        local m = { resource:: resource } + this.util.resource.withConnectionSecretMixin(super.name, namespace),
+        base+: m.base,
+        patches+: m.patches,
+
+        connectionDetails+: connectionDetails,
+      },
 
       // Here are a few common base/patch combinations
 


### PR DESCRIPTION
To do this here, the function below needs access to the attributes in `super`.