### PR TITLE
feat(k8s-gen): add tanka.dev/namespaced annotation if applicable

### DIFF
--- a/pkg/model/gvk.go
+++ b/pkg/model/gvk.go
@@ -115,6 +115,9 @@ type Kind struct {
 
 	// modifiers
 	Modifiers modifiers `json:"modifiers,omitempty"`
+
+	// Cluster or Namespaced scope, ignored if unset
+	Scope *string
 }
 
 // APIVersion constructs the full api path for a group
@@ -171,6 +174,7 @@ func newKind(d swagger.Schema, name string) Kind {
 	kind := Kind{
 		// Help text: description
 		Help: safeStr(d.Desc),
+		Scope: d.Scope,
 	}
 
 	gvk, real := d.GroupVersionKind()

--- a/pkg/swagger/crd.go
+++ b/pkg/swagger/crd.go
@@ -3,6 +3,7 @@ package swagger
 import (
 	"bytes"
 	_ "embed"
+	"fmt"
 	"io"
 	"strings"
 
@@ -54,11 +55,14 @@ func (c *CRDLoader) Load(manifest []byte) (Definitions, error) {
 			nameArray := append(reversed, []string{version.Name, d.Spec.Names.Kind}...)
 			name := strings.Join(nameArray, ".")
 
+			scope := fmt.Sprint(d.Spec.Scope)
+
 			defs[name] = &Schema{
 				Type:  Type(schema.Type),
 				Desc:  schema.Description,
 				Props: c.propToSchema(schema.Properties, true),
 				Items: c.itemsToSchema(schema.Items),
+				Scope: &scope,
 				XGvk: []XGvk{
 					{
 						Group:   d.Spec.Group,

--- a/pkg/swagger/schema.go
+++ b/pkg/swagger/schema.go
@@ -30,6 +30,9 @@ type Schema struct {
 	DollarRef   *string `json:"$ref"`
 	ResolvedRef string
 
+	// Cluster or Namespaced scope, ignored if unset
+	Scope *string
+
 	// vendor extensions
 	XGvk []XGvk `json:"x-kubernetes-group-version-kind"`
 }


### PR DESCRIPTION
Tanka namespaces objects based on the environment they are deployed in, there is
a built-in list to ensure cluster-wide resources are not namespaced, but this list only
covers the native k8s resources. Tanka provides an annotation mechanism to exclude
a certain object from this namespace behavior: https://tanka.dev/namespaces/#cluster-wide-resources

CRDs can tell us which resources are 'Cluster' scoped, this PR uses that information and
adds the Tanka-specific annotation to the `new()` function so all newly created objects
receive that annotation. This might be a bit superfluous for non-Tanka users but I don't
think it does much harm either.