### PR TITLE
feat: support nested object types in array

### DIFF
--- a/libs/kubevela/config.jsonnet
+++ b/libs/kubevela/config.jsonnet
@@ -15,6 +15,7 @@ config.new(
         '%s/core.oam.dev_componentdefinitions.yaml' % url,
         '%s/core.oam.dev_definitionrevisions.yaml' % url,
         '%s/core.oam.dev_envbindings.yaml' % url,
+        '%s/core.oam.dev_healthscopes.yaml' % url,
         '%s/core.oam.dev_manualscalertraits.yaml' % url,
         '%s/core.oam.dev_policies.yaml' % url,
         '%s/core.oam.dev_policydefinitions.yaml' % url,

--- a/pkg/builder/objects.go
+++ b/pkg/builder/objects.go
@@ -42,7 +42,9 @@ func Object(name string, children ...Type) ObjectType {
 
 func escapeKey(s string) string {
 	switch s {
-	case "local", "error", "function", "import", "null":
+	case "assert", "else", "error", "false", "for", "function", "if",
+		"import", "importstr", "in", "local", "null", "tailstrict", 
+		"then", "self", "super", "true":
 		return fmt.Sprintf(`'%s'`, s)
 	default:
 		if strings.HasPrefix(s, "#") {

--- a/pkg/model/gvk.go
+++ b/pkg/model/gvk.go
@@ -185,7 +185,7 @@ func newKind(d swagger.Schema, name string) Kind {
 	}
 
 	// modifiers for properties
-	kind.Modifiers = modsForProps(d.Props, "", true)
+	kind.Modifiers = modsForProps(d.Props, "", true, false, false)
 
 	// real resource? add constructor, remove withKind
 	if real {

--- a/pkg/model/modifiers.go
+++ b/pkg/model/modifiers.go
@@ -133,11 +133,7 @@ func newModifier(name string, p *swagger.Schema, ctx string, inArray bool,
 			Type:   p.Type,
 		}
 
-		funcPrefix := "with"
-		if defArray {
-			funcPrefix = "arrayWith"
-		}
-		return fmt.Sprintf("%s%s", funcPrefix, normalizedTitle(name)), fn
+		return fmt.Sprintf("with%s", normalizedTitle(name)), fn
 	}
 }
 
@@ -145,7 +141,9 @@ func newModifier(name string, p *swagger.Schema, ctx string, inArray bool,
 func fnArg(name string) string {
 	name = strings.Replace(name, "-", "_", -1);
 	switch name {
-	case "assert", "else", "error", "false", "for", "function", "if",
+	case "error": // for backward compatibility
+		return "err"
+	case "assert", "else", "false", "for", "function", "if",
 		"import", "importstr", "in", "local", "null", "tailstrict", 
 		"then", "self", "super", "true":
 		return normalizedTitle(name)


### PR DESCRIPTION
This PR aims to get a meaningful code generation from kubevela while remaining backward-compatibility. Two improvements are contained:
- I included all the reserved keywords of jsonnet for id escape in order to get the transpilation  passed. (see https://jsonnet.org/ref/spec.html)
- I found nested object types in array (see example below) are not resolved. this makes the generated kubevela jsonnet useless because 90% of the definitions are ignored. So I added the corresponding logic to generate jsonnet code in this case.

eg. given the crd yml snippet below

```yaml
          spec:
            description: ApplicationSpec is the spec of Application
            properties:
              components:
                items:
                  description: ApplicationComponent describe the component of application
                  properties:
                    name:
                      type: string
                    traits:
                      description: Traits define the trait of one component, the type
                        must be array to keep the order.
                      items:
                        description: ApplicationTrait defines the trait of application
                        properties:
                          name:
                            type: string
                          properties:
                            type: object
                            x-kubernetes-preserve-unknown-fields: true
                        required:
                        - name
                        type: object
                      type: array
                    type:
                      type: string
                  required:
                  - name
                  type: object
                type: array
```
originally, we have the following:

```jsonnet
spec: {
    '#withComponents':: d.fn(help='', args=[d.arg(name='components', type=d.T.array)]),
    withComponents(components): { spec+: { components: if std.isArray(v=components) then components else [components] } },
    '#withComponentsMixin':: d.fn(help='\n\n**Note:** This function appends passed data to existing values', args=[d.arg(name='components', type=d.T.array)]),
    withComponentsMixin(components): { spec+: { components+: if std.isArray(v=components) then components else [components] } }
}
```

now we can have a more completed libsonnet:

```jsonnet
spec: {
    '#withComponents':: d.fn(help='', args=[d.arg(name='components', type=d.T.array)]),
    withComponents(components): { spec+: { components: if std.isArray(v=components) then components else [components] } },
    '#withComponentsMixin':: d.fn(help='\n\n**Note:** This function appends passed data to existing values', args=[d.arg(name='components', type=d.T.array)]),
    withComponentsMixin(components): { spec+: { components+: if std.isArray(v=components) then components else [components] } },
    components: {
        '#arrayWithName':: d.fn(help='', args=[d.arg(name='name', type=d.T.string)]),
        arrayWithName(name): { name: name },
        '#arrayWithTraits':: d.fn(help='"Traits define the trait of one component, the type must be array to keep the order."', args=[d.arg(name='traits', type=d.T.array)]),
        arrayWithTraits(traits): { traits: if std.isArray(v=traits) then traits else [traits] },
        '#arrayWithTraitsMixin':: d.fn(help='"Traits define the trait of one component, the type must be array to keep the order."\n\n**Note:** This function appends passed data to existing values', args=[d.arg(name='traits', type=d.T.array)]),
        arrayWithTraitsMixin(traits): { traits+: if std.isArray(v=traits) then traits else [traits] },
        '#traits':: d.obj(help='"Traits define the trait of one component, the type must be array to keep the order."'),
        traits: {
          '#arrayWithProperties':: d.fn(help='', args=[d.arg(name='properties', type=d.T.object)]),
          arrayWithProperties(properties): { properties: properties },
          '#arrayWithPropertiesMixin':: d.fn(help='\n\n**Note:** This function appends passed data to existing values', args=[d.arg(name='properties', type=d.T.object)]),
          arrayWithPropertiesMixin(properties): { properties+: properties },
          '#arrayWithType':: d.fn(help='', args=[d.arg(name='type', type=d.T.string)]),
          arrayWithType(type): { type: type },
        },
    }
}
```

NOTE: This should be backward compatible. No existing functions are affected. 