### PR TITLE
[contour-libsonnet] added contour version 1.21 and updated 1.20 to latest patch

### DIFF
--- a/libs/contour/config.jsonnet
+++ b/libs/contour/config.jsonnet
@@ -1,6 +1,7 @@
 local config = import 'jsonnet/config.jsonnet';
 local versions = [
-  { version: '1.20', tag: 'v1.20.1'},
+  { version: '1.21', tag: 'v1.21.1'},
+  { version: '1.20', tag: 'v1.20.2'},
   { version: '1.19', tag: 'v1.19.1'},
   { version: '1.18', tag: 'v1.18.3'},
   { version: '1.17', tag: 'v1.17.2'},


### PR DESCRIPTION
## contour-libsonnet

- added contour version 1.21 `v1.21.1`
- updated 1.20 to latest patch `v1.20.2`
