### PR TITLE
Add: kubernetes-secret-generator

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -539,8 +539,28 @@
         "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
       "run": "make libs/kubernetes-nmstate"
+  "kubernetes-secret-generator":
+    "name": "Generate kubernetes-secret-generator Jsonnet library and docs"
+    "needs":
+    - "build"
+    - "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v2"
+    - "uses": "actions/download-artifact@v2"
+      "with":
+        "name": "docker-artifact"
+        "path": "artifacts"
+    - "run": "make load"
+    - "env":
+        "DIFF": "true"
+        "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+        "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
+        "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
+        "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
+      "run": "make libs/kubernetes-secret-generator"
   "kubevela":
-    "name": "Generate KubeVela Jsonnet library and docs"
+    "name": "Generate kubevela Jsonnet library and docs"
     "needs":
     - "build"
     - "repos"
@@ -703,6 +723,9 @@
     - "k8s"
     - "keda"
     - "kube-prometheus"
+    - "kubernetes-nmstate"
+    - "kubernetes-secret-generator"
+    - "kubevela"
     - "kyverno"
     - "litmus-chaos"
     - "openshift"

--- a/libs/kubernetes-secret-generator/config.jsonnet
+++ b/libs/kubernetes-secret-generator/config.jsonnet
@@ -1,0 +1,20 @@
+local config = import 'jsonnet/config.jsonnet';
+
+local version = '3.4.0';
+
+config.new(
+  name='kubernetes-secret-generator',
+  specs=[
+    {
+      local url = 'https://raw.githubusercontent.com/mittwald/kubernetes-secret-generator/v%s/deploy/crds/' % version,
+      output: version,
+      prefix: '^de\\.mittwald\\.secretgenerator\\..*',
+      crds: [
+        '%s/secretgenerator.mittwald.de_basicauths_crd.yaml' % url,
+        '%s/secretgenerator.mittwald.de_sshkeypairs_crd.yaml' % url,
+        '%s/secretgenerator.mittwald.de_stringsecrets_crd.yaml' % url,
+        ],
+      localName: 'kubernetes_secret_generator',
+    },
+  ],
+)


### PR DESCRIPTION
Libraries for the few CRs in the [Kubernetes Secret Generator](https://github.com/mittwald/kubernetes-secret-generator) controller.

There's also something that watches annotations on secrets, but to the best of my knowledge there's no real way (or reason) to generate anything for that, so this is just for the custom objects.