### PR TITLE
Add agent-operator v0.26 

### DIFF
--- a/libs/grafana-agent/config.jsonnet
+++ b/libs/grafana-agent/config.jsonnet
@@ -1,7 +1,8 @@
 local config = import 'jsonnet/config.jsonnet';
 
 local versions = [
-  {output: '0.20', version:'0.20.0'}
+    {output: '0.20', version:'0.20.0'},
+    {output: '0.26', version:'0.26.0-rc.0'},
 ];
 
 config.new(
@@ -16,6 +17,7 @@ config.new(
         '%s/monitoring.grafana.com_logsinstances.yaml' % url,
         '%s/monitoring.grafana.com_metricsinstances.yaml' % url,
         '%s/monitoring.grafana.com_podlogs.yaml' % url,
+        '%s/monitoring.grafana.com_integrations.yaml' % url,
       ],
       localName: 'grafana-agent',
     }


### PR DESCRIPTION
I'd also like to rename the repo and lib to `grafana-agent-operator` but not sure if that's easily done or would break anything?