### PR TITLE
fix: allow `.` to be part of modifiers

### DIFF
--- a/pkg/model/modifiers.go
+++ b/pkg/model/modifiers.go
@@ -140,6 +140,7 @@ func newModifier(name string, p *swagger.Schema, ctx string, inArray bool,
 // fnArg normalizes an arguments name so it does not use any reserved words
 func fnArg(name string) string {
 	name = strings.Replace(name, "-", "_", -1);
+  name = strings.Replace(name, ".", "_", -1)
 	switch name {
 	case "error": // for backward compatibility
 		return "err"
@@ -157,6 +158,8 @@ func normalizedTitle(name string) string {
 	if strings.HasPrefix(name, "-") {
 		name = strings.TrimPrefix(name, "-")
 	}
+
+  name = strings.Replace(name, ".", "_", -1)
 
 	return strings.Title(name)
 }


### PR DESCRIPTION
Blame on you, @aiven :D

They have e.g. this in one of their CRDs:

```
                      pg_partman_bgw.interval:
                        description: pg_partman_bgw.interval Sets the time interval
                          to run pg_partman's scheduled tasks
                        format: int64
                        maximum: 604800
                        minimum: 3600
                        type: integer
```

There's no diff for libraries that are not using it

Signed-off-by: Matthias Riegler <me@xvzf.tech>
