### PR TITLE
feat: added k8s 1.25 and removed legacy k8s 1.19

### DIFF
--- a/libs/k8s/config.jsonnet
+++ b/libs/k8s/config.jsonnet
@@ -1,11 +1,11 @@
 local config = import 'jsonnet/config.jsonnet';
 local versions = [
+  '1.25',
   '1.24',
   '1.23',
   '1.22',
   '1.21',
   '1.20',
-  '1.19',
 ];
 
 config.new(


### PR DESCRIPTION
https://kubernetes.io/blog/2022/08/23/kubernetes-v1-25-release/
