### PR TITLE
chore(strimzi): generate version 0.32.0

### DIFF
--- a/libs/strimzi/config.jsonnet
+++ b/libs/strimzi/config.jsonnet
@@ -1,6 +1,6 @@
 local config = import 'jsonnet/config.jsonnet';
 
-local versions = ['0.23', '0.24'];
+local versions = ['0.23', '0.24', '0.32'];
 
 config.new(
   name='strimzi',


### PR DESCRIPTION
Adding [version 0.32.0 of the strimzi crds](https://github.com/strimzi/strimzi-kafka-operator/releases/tag/0.32.0).