### PR TITLE
Add kube-prometheus 0.11 CRDs

### DIFF
--- a/libs/kube-prometheus/config.jsonnet
+++ b/libs/kube-prometheus/config.jsonnet
@@ -51,5 +51,21 @@ config.new(
       localName: 'kube_prometheus',
       patchDir: 'custom',
     },
+    {
+      output: '0.11',
+      prefix: '^com\\.coreos\\.monitoring\\..*',
+      crds: [
+        'https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/release-0.11/manifests/setup/0alertmanagerConfigCustomResourceDefinition.yaml',
+        'https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/release-0.11/manifests/setup/0alertmanagerCustomResourceDefinition.yaml',
+        'https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/release-0.11/manifests/setup/0podmonitorCustomResourceDefinition.yaml',
+        'https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/release-0.11/manifests/setup/0probeCustomResourceDefinition.yaml',
+        'https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/release-0.11/manifests/setup/0prometheusCustomResourceDefinition.yaml',
+        'https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/release-0.11/manifests/setup/0prometheusruleCustomResourceDefinition.yaml',
+        'https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/release-0.11/manifests/setup/0servicemonitorCustomResourceDefinition.yaml',
+        'https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/release-0.11/manifests/setup/0thanosrulerCustomResourceDefinition.yaml',
+      ],
+      localName: 'kube_prometheus',
+      patchDir: 'custom',
+    },
   ]
 )


### PR DESCRIPTION
I used the release branch instead of the tag because the project [recommends using the branch][1], but I can change it.

[1]: https://github.com/prometheus-operator/kube-prometheus/releases/tag/v0.11.0