### PR TITLE
feat: allow for non-string values in withEnvMap

### DIFF
--- a/libs/k8s/custom/core/core.libsonnet
+++ b/libs/k8s/custom/core/core.libsonnet
@@ -39,13 +39,26 @@ local d = import 'doc-util/main.libsonnet';
             for envvar in env
           ]),
 
-        '#withEnvMap': d.fn(
-          '`withEnvMap` works like `withEnvMixin` but accepts a key/value map, this map is converted a list of core.v1.envVar(key, value)`',
+        '#withEnvMap': d.fn(|||
+
+            `withEnvMap` works like `withEnvMixin` but accepts a key/value map,
+            this map is converted a list of core.v1.envVar(key, value)`.
+
+            If the value is an object instead of a string, it is placed under
+            the `valueFrom` key.
+
+          |||,
           [d.arg('env', d.T.object)]
         ),
         withEnvMap(env)::
           self.withEnvMixin([
-            $.core.v1.envVar.new(k, env[k])
+            (
+              if std.type(env[k]) == 'object' then
+                $.core.v1.envVar.withName(k) +
+                { valueFrom: env[k] }
+              else
+                $.core.v1.envVar.new(k, env[k])
+            )
             for k in std.objectFields(env)
           ]),
 


### PR DESCRIPTION
This allows for users to keep all environment variables in the same place and allows for easy overrides.

I know there already exist helpers like `fromSecretRef` but this would simplify reusable modules quite a bit.

For example, one could have

```
myCoolContainer(extraEnv) :: container.new(...) + container.withEnvMap({
  'SOME_DEFAULT': {secretKeyRef: { name: 'key', foo: 'bar' }}
} + extraEnv)
```

which would then allow the consumers of this container to override it with a static string or a custom secret without having to use `container.withEnv` directly