### PR TITLE
Added Kubernetes 1.26 version

### DIFF
--- a/libs/k8s/config.jsonnet
+++ b/libs/k8s/config.jsonnet
@@ -1,5 +1,6 @@
 local config = import 'jsonnet/config.jsonnet';
 local versions = [
+  '1.26',
   '1.25',
   '1.24',
   '1.23',


### PR DESCRIPTION
Codegen works, not sure if search should be excluded for 1.26, as well.

Resolves #238
Requires [k8s-libsonnet#1](https://github.com/jsonnet-libs/k8s-libsonnet/pull/1)