### PR TITLE
chore(crossplane): update libraries

### DIFF
--- a/libs/crossplane/config.jsonnet
+++ b/libs/crossplane/config.jsonnet
@@ -3,6 +3,15 @@ local config = import 'jsonnet/config.jsonnet';
 config.new(
   name='crossplane',
   specs=[
+    // Crossplane itself
+    // Release support table: https://github.com/crossplane/crossplane#releases
+    {
+      output: 'crossplane/1.10',
+      prefix: '^io\\.crossplane\\.(pkg|apiextensions)\\..*',
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane/crossplane@v1.10.2'],
+      localName: 'crossplane',
+      patchDir: 'custom/crossplane',
+    },
     {
       output: 'crossplane/1.9',
       prefix: '^io\\.crossplane\\.(pkg|apiextensions)\\..*',
@@ -17,47 +26,24 @@ config.new(
       localName: 'crossplane',
       patchDir: 'custom/crossplane',
     },
+
+    // crossplane-contrib
     {
-      output: 'crossplane/1.7',
-      prefix: '^io\\.crossplane\\.(pkg|apiextensions)\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/crossplane@v1.7.0'],
-      localName: 'crossplane',
-      patchDir: 'custom/crossplane',
-    },
-    {
-      output: 'provider-aws/0.24',
+      output: 'provider-aws/0.36',
       prefix: '^io\\.crossplane\\.aws\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/provider-aws@v0.24.1'],
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane/provider-aws@v0.36.1'],
       localName: 'crossplane_aws',
     },
     {
-      output: 'provider-gcp/0.21',
+      output: 'provider-gcp/0.22',
       prefix: '^io\\.crossplane\\.gcp\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/provider-gcp@v0.21.0'],
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane/provider-gcp@v0.22.0'],
       localName: 'crossplane_gcp',
     },
     {
-      output: 'provider-jet-aws/0.5',
-      prefix: '^io\\.crossplane\\.jet\\.aws\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-jet-aws@v0.5.0-preview'],
-      localName: 'crossplane_jet_aws',
-    },
-    {
-      output: 'provider-jet-gcp/0.2',
-      prefix: '^io\\.crossplane\\.jet\\.gcp\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-jet-gcp@v0.2.0-preview'],
-      localName: 'crossplane_jet_gcp',
-    },
-    {
-      output: 'provider-jet-mongodbatlas/0.2',
-      prefix: '^io\\.crossplane\\.jet\\.mongodbatlas\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-jet-mongodbatlas@v0.2.1'],
-      localName: 'crossplane_jet_mongodbatlas',
-    },
-    {
-      output: 'provider-azure/0.19',
+      output: 'provider-azure/0.20',
       prefix: '^io\\.crossplane\\.azure\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/provider-azure@v0.19.0'],
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane/provider-azure@v0.20.0'],
       localName: 'crossplane_azure',
     },
     {
@@ -67,49 +53,51 @@ config.new(
       localName: 'crossplane_sql',
     },
     {
-      output: 'provider-kubernetes/0.3',
+      output: 'provider-kubernetes/0.6',
       prefix: '^io\\.crossplane\\.kubernetes\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-kubernetes@v0.3.0'],
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-kubernetes@v0.6.0'],
       localName: 'crossplane_kubernetes',
     },
     {
-      output: 'provider-grafana/0.0',
-      prefix: '^io\\.crossplane\\.grafana\\..*',
-      crds: ['https://github.com/grafana/crossplane-provider-grafana/releases/download/v0.0.10/crds.yaml'],
-      localName: 'crossplane_grafana',
-    },
-    {
-      output: 'provider-helm/0.10',
+      output: 'provider-helm/0.13',
       prefix: '^io\\.crossplane\\.helm\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-helm@v0.10.0'],
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-helm@v0.13.0'],
       localName: 'crossplane_helm',
     },
+
+    // Grafana
     {
-      output: 'provider-terraform/0.3',
-      prefix: '^io\\.crossplane\\.tf\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-terraform@v0.3.0'],
-      localName: 'crossplane_terraform',
+      output: 'provider-grafana/0.1',
+      prefix: '^io\\.crossplane\\.grafana\\..*',
+      crds: ['https://github.com/grafana/crossplane-provider-grafana/releases/download/v0.1.0/crds.yaml'],
+      localName: 'crossplane_grafana',
     },
 
     // Upbound official providers
     // https://marketplace.upbound.io/
     {
-      output: 'upbound-provider-aws/0.24',
+      output: 'upbound-provider-aws/0.28',
       prefix: '^io\\.upbound\\.aws\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-aws@v0.24.0'],
+      crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-aws@v0.28.0'],
       localName: 'upbound_aws',
     },
     {
-      output: 'upbound-provider-azure/0.19',
+      output: 'upbound-provider-azure/0.26',
       prefix: '^io\\.upbound\\.azure\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-azure@v0.19.0'],
+      crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-azure@v0.26.0'],
       localName: 'upbound_azure',
     },
     {
-      output: 'upbound-provider-gcp/0.19',
+      output: 'upbound-provider-gcp/0.26',
       prefix: '^io\\.upbound\\.gcp\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-gcp@v0.19.0'],
+      crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-gcp@v0.26.0'],
       localName: 'upbound_gcp',
+    },
+    {
+      output: 'provider-terraform/0.4',
+      prefix: '^io\\.upbound\\.tf\\..*',
+      crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-terraform@v0.4.0'],
+      localName: 'crossplane_terraform',
     },
   ]
 )

--- a/libs/crossplane/config.jsonnet
+++ b/libs/crossplane/config.jsonnet
@@ -64,6 +64,12 @@ config.new(
       crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-helm@v0.13.0'],
       localName: 'crossplane_helm',
     },
+    {
+      output: 'provider-jet-mongodbatlas/0.3',
+      prefix: '^io\\.crossplane\\.jet\\.mongodbatlas\\..*',
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-jet-mongodbatlas@v0.3.0'],
+      localName: 'crossplane_jet_mongodbatlas',
+    },
 
     // Grafana
     {


### PR DESCRIPTION
Update several libraries:
- Add Crossplane 1.10
- Remove unsupported Crossplane 1.7
- Update contrib providers
- Update Grafana provider
- Replace provider-terraform with the upbound official one
- Remove terrajet based providers in favor of the upbound official providers
- Update upbound official providers

This PR also restructures the file a bit.

This PR replaces #263 