### PR TITLE
feat(vertical-pod-autoscaler): add withTargetRef patch

### DIFF
--- a/libs/vertical-pod-autoscaler/custom/core/autoscaling.libsonnet
+++ b/libs/vertical-pod-autoscaler/custom/core/autoscaling.libsonnet
@@ -1,6 +1,20 @@
 local d = import 'doc-util/main.libsonnet';
 
+local withTargetRef = {
+  '#withTargetRef':: d.fn(help='Set spec.TargetRef to `object`', args=[d.arg(name='object', type=d.T.object)]),
+  withTargetRef(object):
+    { spec+: { targetRef+: {
+      apiVersion: object.apiVersion,
+      kind: object.kind,
+      name: object.metadata.name,
+    } } },
+};
+
 local patch = {
+  verticalPodAutoscaler+: {
+    spec+: withTargetRef,
+  },
+
   verticalPodAutoscalerContainerResourcePolicy+: {
     '#':: d.pkg(
       name='verticalPodAutoscalerContainerResourcePolicy',


### PR DESCRIPTION
Add a `withTargetRef` patch to the VerticalPodAutoscaler to set the `spec.targetRef` field to the given object, mirroring the `withScaleTargetRef` patch applied to the HorizontalPodAutoscaler.