### PR TITLE
fix(crossplane): generate upbound providers properly

### DIFF
--- a/libs/crossplane/config.jsonnet
+++ b/libs/crossplane/config.jsonnet
@@ -103,7 +103,7 @@ config.new(
       output: 'provider-terraform/0.4',
       prefix: '^io\\.upbound\\.tf\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-terraform@v0.4.0'],
-      localName: 'crossplane_terraform',
+      localName: 'upbound_terraform',
     },
   ]
 )


### PR DESCRIPTION
The upbound provideres weren't generated properly, this was due to doc.crds.dev not being
aware of the new versions and returning an empty/error response. The new versions get
generated when visited through a browser.

This should probably be checked for and returned with an error in the code, but I haven't
had time to look why that isn't happening.