### PR TITLE
Allow `volumeMount` helpers to optionally act on `initContainers`

### DIFF
--- a/libs/k8s/custom/core/mapContainers.libsonnet
+++ b/libs/k8s/custom/core/mapContainers.libsonnet
@@ -20,7 +20,7 @@ local patch = {
       template+: {
         spec+: {
           containers: std.map(f, podContainers),
-              initContainers: if includeInitContainers then std.map(f, podInitContainers) else podInitContainers,
+          [if includeInitContainers then 'initContainers']: std.map(f, podInitContainers),
         },
       },
     },
@@ -46,7 +46,7 @@ local cronPatch = patch {
           template+: {
             spec+: {
               containers: std.map(f, podContainers),
-              initContainers: if includeInitContainers then std.map(f, podInitContainers) else podInitContainers,
+              [if includeInitContainers then 'initContainers']: std.map(f, podInitContainers),
             },
           },
         },

--- a/libs/k8s/custom/core/mapContainers.libsonnet
+++ b/libs/k8s/custom/core/mapContainers.libsonnet
@@ -13,12 +13,14 @@ local patch = {
     |||,
     [d.arg('f', d.T.func)]
   ),
-  mapContainers(f):: {
+  mapContainers(f, includeInitContainers=false):: {
     local podContainers = super.spec.template.spec.containers,
+    local podInitContainers = super.spec.template.spec.initContainers,
     spec+: {
       template+: {
         spec+: {
           containers: std.map(f, podContainers),
+              initContainers: if includeInitContainers then std.map(f, podInitContainers) else podInitContainers,
         },
       },
     },
@@ -26,23 +28,25 @@ local patch = {
 
   '#mapContainersWithName': d.fn('`mapContainersWithName` is like `mapContainers`, but only applies to those containers in the `names` array',
     [d.arg('names', d.T.array), d.arg('f', d.T.func)]),
-  mapContainersWithName(names, f)::
+  mapContainersWithName(names, f, includeInitContainers=false)::
     local nameSet = if std.type(names) == 'array' then std.set(names) else std.set([names]);
     local inNameSet(name) = std.length(std.setInter(nameSet, std.set([name]))) > 0;
 
-    self.mapContainers(function(c) if std.objectHas(c, 'name') && inNameSet(c.name) then f(c) else c),
+    self.mapContainers(function(c) if std.objectHas(c, 'name') && inNameSet(c.name) then f(c) else c, includeInitContainers),
 };
 
 // batch.job and batch.cronJob have the podSpec at a different location
 local cronPatch = patch {
-  mapContainers(f):: {
+  mapContainers(f, includeInitContainers=false):: {
     local podContainers = super.spec.jobTemplate.spec.template.spec.containers,
+    local podInitContainers = super.spec.jobTemplate.spec.template.spec.initContainers,
     spec+: {
       jobTemplate+: {
         spec+: {
           template+: {
             spec+: {
               containers: std.map(f, podContainers),
+              initContainers: if includeInitContainers then std.map(f, podInitContainers) else podInitContainers,
             },
           },
         },

--- a/libs/k8s/custom/core/mapContainers.libsonnet
+++ b/libs/k8s/custom/core/mapContainers.libsonnet
@@ -64,8 +64,6 @@ local cronPatch = patch {
   batch+: {
     v1+: {
       job+: patch,
-    },
-    v1beta1+: {
       cronJob+: cronPatch,
     },
   },

--- a/libs/k8s/custom/core/mapContainers.libsonnet
+++ b/libs/k8s/custom/core/mapContainers.libsonnet
@@ -66,6 +66,9 @@ local cronPatch = patch {
       job+: patch,
       cronJob+: cronPatch,
     },
+    v1beta1+: {
+      cronJob+: cronPatch,
+    },
   },
   apps+: { v1+: {
     daemonSet+: patch,

--- a/libs/k8s/custom/core/volumeMounts.libsonnet
+++ b/libs/k8s/custom/core/volumeMounts.libsonnet
@@ -45,7 +45,7 @@ local d = import 'doc-util/main.libsonnet';
       );
       local volumeMixins = [volume.fromConfigMap(name, name) + volumeMixin];
 
-      super.mapContainers(addMount) +
+      super.mapContainers(addMount, includeInitContainers=includeInitContainers) +
       if std.objectHas(super.spec, 'template')
       then super.spec.template.spec.withVolumesMixin(volumeMixins)
       else super.spec.jobTemplate.spec.template.spec.withVolumesMixin(volumeMixins),
@@ -87,7 +87,7 @@ local d = import 'doc-util/main.libsonnet';
       local volumeMixins = [volume.fromConfigMap(name, name) + volumeMixin];
       local annotations = {['%s-hash' % name]: hash};
 
-      super.mapContainers(addMount) +
+      super.mapContainers(addMount, includeInitContainers=includeInitContainers) +
       if std.objectHas(super.spec, 'template')
       then
         super.spec.template.spec.withVolumesMixin(volumeMixins) +
@@ -130,7 +130,7 @@ local d = import 'doc-util/main.libsonnet';
       );
       local volumeMixins = [volume.fromHostPath(name, hostPath) + volumeMixin];
 
-      super.mapContainers(addMount) +
+      super.mapContainers(addMount, includeInitContainers=includeInitContainers) +
       if std.objectHas(super.spec, 'template')
       then super.spec.template.spec.withVolumesMixin(volumeMixins)
       else super.spec.jobTemplate.spec.template.spec.withVolumesMixin(volumeMixins),
@@ -168,7 +168,7 @@ local d = import 'doc-util/main.libsonnet';
       );
       local volumeMixins = [volume.fromPersistentVolumeClaim(name, name) + volumeMixin];
 
-      super.mapContainers(addMount) +
+      super.mapContainers(addMount, includeInitContainers=includeInitContainers) +
       if std.objectHas(super.spec, 'template')
       then super.spec.template.spec.withVolumesMixin(volumeMixins)
       else super.spec.jobTemplate.spec.template.spec.withVolumesMixin(volumeMixins),
@@ -210,7 +210,7 @@ local d = import 'doc-util/main.libsonnet';
         volumeMixin,
       ];
 
-      super.mapContainers(addMount) +
+      super.mapContainers(addMount, includeInitContainers=includeInitContainers) +
       if std.objectHas(super.spec, 'template')
       then super.spec.template.spec.withVolumesMixin(volumeMixins)
       else super.spec.jobTemplate.spec.template.spec.withVolumesMixin(volumeMixins),
@@ -264,7 +264,7 @@ local d = import 'doc-util/main.libsonnet';
       );
       local volumeMixins = [volume.fromEmptyDir(name) + volumeMixin];
 
-      super.mapContainers(addMount) +
+      super.mapContainers(addMount, includeInitContainers=includeInitContainers) +
       if std.objectHas(super.spec, 'template')
       then super.spec.template.spec.withVolumesMixin(volumeMixins)
       else super.spec.jobTemplate.spec.template.spec.withVolumesMixin(volumeMixins),
@@ -300,7 +300,7 @@ local d = import 'doc-util/main.libsonnet';
       );
       local volumeMixins = [volume.fromCsi(name, driver, volumeAttributes) + volumeMixin];
 
-      super.mapContainers(addMount) +
+      super.mapContainers(addMount, includeInitContainers=includeInitContainers) +
       if std.objectHas(super.spec, 'template')
       then super.spec.template.spec.withVolumesMixin(volumeMixins)
       else super.spec.jobTemplate.spec.template.spec.withVolumesMixin(volumeMixins),

--- a/libs/k8s/custom/core/volumeMounts.libsonnet
+++ b/libs/k8s/custom/core/volumeMounts.libsonnet
@@ -22,7 +22,7 @@ local d = import 'doc-util/main.libsonnet';
         to those containers, otherwise it will be mounted on all containers.
 
         This helper function can be augmented with a `volumeMixin`. For example,
-        passing "k.core.v1.volume.configMap.withDefaultMode(420)" will result in a 
+        passing "k.core.v1.volume.configMap.withDefaultMode(420)" will result in a
         default mode mixin.
       |||
       + volumeMountDescription,
@@ -34,7 +34,7 @@ local d = import 'doc-util/main.libsonnet';
         d.arg('containers', d.T.array),
       ]
     ),
-    configVolumeMount(name, path, volumeMountMixin={}, volumeMixin={}, containers=null)::
+    configVolumeMount(name, path, volumeMountMixin={}, volumeMixin={}, containers=null, includeInitContainers=false)::
       local addMount(c) = c + (
         if containers == null || std.member(containers, c.name)
         then container.withVolumeMountsMixin(
@@ -44,7 +44,7 @@ local d = import 'doc-util/main.libsonnet';
         else {}
       );
 
-      super.mapContainers(addMount) +
+      super.mapContainers(addMount, includeInitContainers) +
       super.spec.template.spec.withVolumesMixin([
         volume.fromConfigMap(name, name) +
         volumeMixin,
@@ -61,7 +61,7 @@ local d = import 'doc-util/main.libsonnet';
         to those containers, otherwise it will be mounted on all containers.
 
         This helper function can be augmented with a `volumeMixin`. For example,
-        passing "k.core.v1.volume.configMap.withDefaultMode(420)" will result in a 
+        passing "k.core.v1.volume.configMap.withDefaultMode(420)" will result in a
         default mode mixin.
       |||
       + volumeMountDescription,
@@ -73,7 +73,7 @@ local d = import 'doc-util/main.libsonnet';
         d.arg('containers', d.T.array),
       ]
     ),
-    configMapVolumeMount(configMap, path, volumeMountMixin={}, volumeMixin={}, containers=null)::
+    configMapVolumeMount(configMap, path, volumeMountMixin={}, volumeMixin={}, containers=null, includeInitContainers=false)::
       local name = configMap.metadata.name,
             hash = std.md5(std.toString(configMap));
       local addMount(c) = c + (
@@ -85,7 +85,7 @@ local d = import 'doc-util/main.libsonnet';
         else {}
       );
 
-      super.mapContainers(addMount) +
+      super.mapContainers(addMount, includeInitContainers) +
       super.spec.template.spec.withVolumesMixin([
         volume.fromConfigMap(name, name) +
         volumeMixin,
@@ -103,7 +103,7 @@ local d = import 'doc-util/main.libsonnet';
         to those containers, otherwise it will be mounted on all containers.
 
         This helper function can be augmented with a `volumeMixin`. For example,
-        passing "k.core.v1.volume.hostPath.withType('Socket')" will result in a 
+        passing "k.core.v1.volume.hostPath.withType('Socket')" will result in a
         socket type mixin.
       |||
       + volumeMountDescription,
@@ -117,7 +117,7 @@ local d = import 'doc-util/main.libsonnet';
         d.arg('containers', d.T.array),
       ]
     ),
-    hostVolumeMount(name, hostPath, path, readOnly=false, volumeMountMixin={}, volumeMixin={}, containers=null)::
+    hostVolumeMount(name, hostPath, path, readOnly=false, volumeMountMixin={}, volumeMixin={}, containers=null, includeInitContainers=false)::
       local addMount(c) = c + (
         if containers == null || std.member(containers, c.name)
         then container.withVolumeMountsMixin(
@@ -127,7 +127,7 @@ local d = import 'doc-util/main.libsonnet';
         else {}
       );
 
-      super.mapContainers(addMount) +
+      super.mapContainers(addMount, includeInitContainers) +
       super.spec.template.spec.withVolumesMixin([
         volume.fromHostPath(name, hostPath) +
         volumeMixin,
@@ -142,7 +142,7 @@ local d = import 'doc-util/main.libsonnet';
         to those containers, otherwise it will be mounted on all containers.
 
         This helper function can be augmented with a `volumeMixin`. For example,
-        passing "k.core.v1.volume.persistentVolumeClaim.withReadOnly(true)" will result in a 
+        passing "k.core.v1.volume.persistentVolumeClaim.withReadOnly(true)" will result in a
         mixin that forces all container mounts to be read-only.
       |||
       + volumeMountDescription,
@@ -155,7 +155,7 @@ local d = import 'doc-util/main.libsonnet';
         d.arg('containers', d.T.array),
       ]
     ),
-    pvcVolumeMount(name, path, readOnly=false, volumeMountMixin={}, volumeMixin={}, containers=null)::
+    pvcVolumeMount(name, path, readOnly=false, volumeMountMixin={}, volumeMixin={}, containers=null, includeInitContainers=false)::
       local addMount(c) = c + (
         if containers == null || std.member(containers, c.name)
         then container.withVolumeMountsMixin(
@@ -165,7 +165,7 @@ local d = import 'doc-util/main.libsonnet';
         else {}
       );
 
-      super.mapContainers(addMount) +
+      super.mapContainers(addMount, includeInitContainers) +
       super.spec.template.spec.withVolumesMixin([
         volume.fromPersistentVolumeClaim(name, name) +
         volumeMixin,
@@ -180,7 +180,7 @@ local d = import 'doc-util/main.libsonnet';
         to those containers, otherwise it will be mounted on all containers.
 
         This helper function can be augmented with a `volumeMixin`. For example,
-        passing "k.core.v1.volume.secret.withOptional(true)" will result in a 
+        passing "k.core.v1.volume.secret.withOptional(true)" will result in a
         mixin that allows the secret to be optional.
       |||
       + volumeMountDescription,
@@ -193,7 +193,7 @@ local d = import 'doc-util/main.libsonnet';
         d.arg('containers', d.T.array),
       ]
     ),
-    secretVolumeMount(name, path, defaultMode=256, volumeMountMixin={}, volumeMixin={}, containers=null)::
+    secretVolumeMount(name, path, defaultMode=256, volumeMountMixin={}, volumeMixin={}, containers=null, includeInitContainers=false)::
       local addMount(c) = c + (
         if containers == null || std.member(containers, c.name)
         then container.withVolumeMountsMixin(
@@ -203,7 +203,7 @@ local d = import 'doc-util/main.libsonnet';
         else {}
       );
 
-      super.mapContainers(addMount) +
+      super.mapContainers(addMount, includeInitContainers) +
       super.spec.template.spec.withVolumesMixin([
         volume.fromSecret(name, secretName=name) +
         volume.secret.withDefaultMode(defaultMode) +
@@ -222,7 +222,7 @@ local d = import 'doc-util/main.libsonnet';
         d.arg('containers', d.T.array),
       ]
     ),
-    secretVolumeMountAnnotated(name, path, defaultMode=256, volumeMountMixin={}, volumeMixin={}, containers=null)::
+    secretVolumeMountAnnotated(name, path, defaultMode=256, volumeMountMixin={}, volumeMixin={}, containers=null, includeInitContainers=false)::
       local annotations = { ['%s-secret-hash' % name]: std.md5(std.toString(name)) };
 
       self.secretVolumeMount(name, path, defaultMode, volumeMountMixin, volumeMixin, containers)
@@ -236,7 +236,7 @@ local d = import 'doc-util/main.libsonnet';
         to those containers, otherwise it will be mounted on all containers.
 
         This helper function can be augmented with a `volumeMixin`. For example,
-        passing "k.core.v1.volume.emptyDir.withSizeLimit('100Mi')" will result in a 
+        passing "k.core.v1.volume.emptyDir.withSizeLimit('100Mi')" will result in a
         mixin that limits the size of the volume to 100Mi.
       |||
       + volumeMountDescription,
@@ -248,7 +248,7 @@ local d = import 'doc-util/main.libsonnet';
         d.arg('containers', d.T.array),
       ]
     ),
-    emptyVolumeMount(name, path, volumeMountMixin={}, volumeMixin={}, containers=null)::
+    emptyVolumeMount(name, path, volumeMountMixin={}, volumeMixin={}, containers=null, includeInitContainers=false)::
       local addMount(c) = c + (
         if containers == null || std.member(containers, c.name)
         then container.withVolumeMountsMixin(
@@ -258,18 +258,18 @@ local d = import 'doc-util/main.libsonnet';
         else {}
       );
 
-      super.mapContainers(addMount) +
+      super.mapContainers(addMount, includeInitContainers) +
       super.spec.template.spec.withVolumesMixin([
         volume.fromEmptyDir(name) + volumeMixin,
       ]),
-    
+
     '#csiVolumeMount': d.fn(
       |||
         `csiVolumeMount` mounts CSI volume by `name` into all container on `path`.
         If `containers` is specified as an array of container names it will only be mounted
         to those containers, otherwise it will be mounted on all containers.
         This helper function can be augmented with a `volumeMixin`. For example,
-        passing "k.core.v1.volume.csi.withReadOnly(false)" will result in a 
+        passing "k.core.v1.volume.csi.withReadOnly(false)" will result in a
         mixin that makes the volume writeable.
       |||
       + volumeMountDescription,
@@ -283,7 +283,7 @@ local d = import 'doc-util/main.libsonnet';
         d.arg('containers', d.T.array),
       ]
     ),
-    csiVolumeMount(name, path, driver, volumeAttributes, volumeMountMixin={}, volumeMixin={}, containers=null)::
+    csiVolumeMount(name, path, driver, volumeAttributes, volumeMountMixin={}, volumeMixin={}, containers=null, includeInitContainers=false)::
       local addMount(c) = c + (
         if containers == null || std.member(containers, c.name)
         then container.withVolumeMountsMixin(
@@ -292,7 +292,7 @@ local d = import 'doc-util/main.libsonnet';
         )
         else {}
       );
-      super.mapContainers(addMount) +
+      super.mapContainers(addMount, includeInitContainers) +
       super.spec.template.spec.withVolumesMixin([
         volume.fromCsi(name, driver, volumeAttributes) + volumeMixin,
       ]),

--- a/libs/k8s/custom/core/volumeMounts.libsonnet
+++ b/libs/k8s/custom/core/volumeMounts.libsonnet
@@ -318,6 +318,9 @@ local d = import 'doc-util/main.libsonnet';
       job+: patch,
       cronJob+: patch,
     },
+    v1beta1+: {
+      cronJob+: patch,
+    },
   },
   apps+: { v1+: {
     daemonSet+: patch,

--- a/libs/k8s/custom/core/volumeMounts.libsonnet
+++ b/libs/k8s/custom/core/volumeMounts.libsonnet
@@ -43,13 +43,6 @@ local d = import 'doc-util/main.libsonnet';
         )
         else {}
       );
-
-      super.mapContainers(addMount, includeInitContainers) +
-      super.spec.template.spec.withVolumesMixin([
-        volume.fromConfigMap(name, name) +
-        volumeMixin,
-      ]),
-
       local volumeMixins = [volume.fromConfigMap(name, name) + volumeMixin];
 
       super.mapContainers(addMount) +

--- a/libs/k8s/custom/core/volumeMounts.libsonnet
+++ b/libs/k8s/custom/core/volumeMounts.libsonnet
@@ -50,6 +50,13 @@ local d = import 'doc-util/main.libsonnet';
         volumeMixin,
       ]),
 
+      local volumeMixins = [volume.fromConfigMap(name, name) + volumeMixin];
+
+      super.mapContainers(addMount) +
+      if std.objectHas(super.spec, 'template')
+      then super.spec.template.spec.withVolumesMixin(volumeMixins)
+      else super.spec.jobTemplate.spec.template.spec.withVolumesMixin(volumeMixins),
+
 
     '#configMapVolumeMount': d.fn(
       |||
@@ -84,15 +91,17 @@ local d = import 'doc-util/main.libsonnet';
         )
         else {}
       );
+      local volumeMixins = [volume.fromConfigMap(name, name) + volumeMixin];
+      local annotations = {['%s-hash' % name]: hash};
 
-      super.mapContainers(addMount, includeInitContainers) +
-      super.spec.template.spec.withVolumesMixin([
-        volume.fromConfigMap(name, name) +
-        volumeMixin,
-      ]) +
-      super.spec.template.metadata.withAnnotationsMixin({
-        ['%s-hash' % name]: hash,
-      }),
+      super.mapContainers(addMount) +
+      if std.objectHas(super.spec, 'template')
+      then
+        super.spec.template.spec.withVolumesMixin(volumeMixins) +
+        super.spec.template.metadata.withAnnotationsMixin(annotations)
+      else
+        super.spec.jobTemplate.spec.template.spec.withVolumesMixin(volumeMixins) +
+        super.spec.jobTemplate.spec.template.metadata.withAnnotationsMixin(annotations),
 
 
     '#hostVolumeMount': d.fn(
@@ -126,12 +135,12 @@ local d = import 'doc-util/main.libsonnet';
         )
         else {}
       );
+      local volumeMixins = [volume.fromHostPath(name, hostPath) + volumeMixin];
 
-      super.mapContainers(addMount, includeInitContainers) +
-      super.spec.template.spec.withVolumesMixin([
-        volume.fromHostPath(name, hostPath) +
-        volumeMixin,
-      ]),
+      super.mapContainers(addMount) +
+      if std.objectHas(super.spec, 'template')
+      then super.spec.template.spec.withVolumesMixin(volumeMixins)
+      else super.spec.jobTemplate.spec.template.spec.withVolumesMixin(volumeMixins),
 
 
     '#pvcVolumeMount': d.fn(
@@ -164,12 +173,12 @@ local d = import 'doc-util/main.libsonnet';
         )
         else {}
       );
+      local volumeMixins = [volume.fromPersistentVolumeClaim(name, name) + volumeMixin];
 
-      super.mapContainers(addMount, includeInitContainers) +
-      super.spec.template.spec.withVolumesMixin([
-        volume.fromPersistentVolumeClaim(name, name) +
-        volumeMixin,
-      ]),
+      super.mapContainers(addMount) +
+      if std.objectHas(super.spec, 'template')
+      then super.spec.template.spec.withVolumesMixin(volumeMixins)
+      else super.spec.jobTemplate.spec.template.spec.withVolumesMixin(volumeMixins),
 
 
     '#secretVolumeMount': d.fn(
@@ -202,13 +211,16 @@ local d = import 'doc-util/main.libsonnet';
         )
         else {}
       );
-
-      super.mapContainers(addMount, includeInitContainers) +
-      super.spec.template.spec.withVolumesMixin([
+      local volumeMixins = [
         volume.fromSecret(name, secretName=name) +
         volume.secret.withDefaultMode(defaultMode) +
         volumeMixin,
-      ]),
+      ];
+
+      super.mapContainers(addMount) +
+      if std.objectHas(super.spec, 'template')
+      then super.spec.template.spec.withVolumesMixin(volumeMixins)
+      else super.spec.jobTemplate.spec.template.spec.withVolumesMixin(volumeMixins),
 
     '#secretVolumeMountAnnotated': d.fn(
       'same as `secretVolumeMount`, adding an annotation to force redeploy on change.'
@@ -257,11 +269,12 @@ local d = import 'doc-util/main.libsonnet';
         )
         else {}
       );
+      local volumeMixins = [volume.fromEmptyDir(name) + volumeMixin];
 
-      super.mapContainers(addMount, includeInitContainers) +
-      super.spec.template.spec.withVolumesMixin([
-        volume.fromEmptyDir(name) + volumeMixin,
-      ]),
+      super.mapContainers(addMount) +
+      if std.objectHas(super.spec, 'template')
+      then super.spec.template.spec.withVolumesMixin(volumeMixins)
+      else super.spec.jobTemplate.spec.template.spec.withVolumesMixin(volumeMixins),
 
     '#csiVolumeMount': d.fn(
       |||
@@ -292,15 +305,18 @@ local d = import 'doc-util/main.libsonnet';
         )
         else {}
       );
-      super.mapContainers(addMount, includeInitContainers) +
-      super.spec.template.spec.withVolumesMixin([
-        volume.fromCsi(name, driver, volumeAttributes) + volumeMixin,
-      ]),
+      local volumeMixins = [volume.fromCsi(name, driver, volumeAttributes) + volumeMixin];
+
+      super.mapContainers(addMount) +
+      if std.objectHas(super.spec, 'template')
+      then super.spec.template.spec.withVolumesMixin(volumeMixins)
+      else super.spec.jobTemplate.spec.template.spec.withVolumesMixin(volumeMixins),
   },
 
   batch+: {
     v1+: {
       job+: patch,
+      cronJob+: patch,
     },
   },
   apps+: { v1+: {


### PR DESCRIPTION
Currently, `mapContainers` only acts on `containers` and not `initContainers`. This add an option to also map `initContainers`.

I am open to an alternative of adding separate `mapInitContainers` help methods, however, this seems most user friendly. 

An example of where this would be useful is here: https://github.com/jsonnet-libs/k8s/blob/450a1f2a0d89d90faad2fc1eef7b8654d8daeab4/libs/k8s/custom/core/volumeMounts.libsonnet#L76-L95

It seems likely that when mounting volumes one probably wants to also mount them to `initContainers` as copying data from `initContainers` to `containers` is a fairly common pattern.

Closes #223 