### PR TITLE
chore(keda): add 2.8 and 2.9 versions

### DIFF
--- a/libs/keda/config.jsonnet
+++ b/libs/keda/config.jsonnet
@@ -2,7 +2,9 @@ local config = import 'jsonnet/config.jsonnet';
 
 local versions = [
   {output: '2.6', version:'2.6.1'},
-  {output: '2.7', version:'2.7.1'}
+  {output: '2.7', version:'2.7.1'},
+  {output: '2.8', version:'2.8.2'},
+  {output: '2.9', version:'2.9.3'}
 ];
 
 config.new(


### PR DESCRIPTION
Similar to https://github.com/jsonnet-libs/k8s/pull/254 but with the most recent versions.