### PR TITLE
feat: add teleport-operator 12.2.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1619,6 +1619,7 @@
     - "secrets-store-csi-driver"
     - "securecodebox"
     - "strimzi"
+    - "teleport-operator"
     - "traefik"
     - "vertical-pod-autoscaler"
     - "zalando-postgres-operator"
@@ -1776,6 +1777,46 @@
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
       "if": "steps.filter.outputs.workflows == 'true'"
       "run": "make libs/strimzi"
+  "teleport-operator":
+    "name": "Generate teleport-operator Jsonnet library and docs"
+    "needs":
+    - "build"
+    - "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v2"
+    - "id": "filter"
+      "uses": "dorny/paths-filter@v2"
+      "with":
+        "filters": |
+          workflows:
+            - '.github/**'
+            - 'bin/**'
+            - 'Dockerfile'
+            - 'go.mod'
+            - 'go.sum'
+            - 'jsonnet/**'
+            - 'main.go'
+            - 'Makefile'
+            - 'pkg/**'
+            - 'scripts/**'
+            - 'tf/**'
+            - 'libs/teleport-operator/**'
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "uses": "actions/download-artifact@v2"
+      "with":
+        "name": "docker-artifact"
+        "path": "artifacts"
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make load"
+    - "env":
+        "DIFF": "true"
+        "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+        "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
+        "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
+        "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
+      "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make libs/teleport-operator"
   "traefik":
     "name": "Generate traefik Jsonnet library and docs"
     "needs":

--- a/libs/teleport-operator/config.jsonnet
+++ b/libs/teleport-operator/config.jsonnet
@@ -1,0 +1,27 @@
+local config = import 'jsonnet/config.jsonnet';
+local versions = ['12.2.2'];
+local manifests = [
+  'resources.teleport.dev_githubconnectors.yaml',
+  'resources.teleport.dev_loginrules.yaml',
+  'resources.teleport.dev_oidcconnectors.yaml',
+  'resources.teleport.dev_roles.yaml',
+  'resources.teleport.dev_samlconnectors.yaml',
+  'resources.teleport.dev_users.yaml',
+];
+
+config.new(
+  name='teleport-operator',
+  specs=[
+    {
+      output: std.join('.', std.split(version, '.')[:2]),
+      prefix: '^dev\\.teleport\\.resources\\..*',
+      localName: 'teleport-operator',
+      crds: [
+        'https://raw.githubusercontent.com/gravitational/teleport/v%s/examples/chart/teleport-cluster/charts/teleport-operator/templates/%s' %
+        [version, manifest]
+        for manifest in manifests
+      ],
+    }
+    for version in versions
+  ]
+)


### PR DESCRIPTION
Adding new jsonnet-lib, teleport-operator 12.2.2. This references the [custom resource definitions in the teleport repo](https://github.com/gravitational/teleport/tree/v12.2.2/examples/chart/teleport-cluster/charts/teleport-operator/templates).