### PR TITLE
Revert generating status attributes

### DIFF
--- a/pkg/model/modifiers.go
+++ b/pkg/model/modifiers.go
@@ -18,7 +18,7 @@ const (
 
 var propertiesWithoutModifiers = map[string]excludeType{
 	"apiVersion": excludeInRootOnly,
-	"status":     excludeInRootOnly,
+	"status":     excludeEverywhere,
 }
 
 // Modifier is a function that returns a patch to modify the value at `Target`


### PR DESCRIPTION
From https://github.com/jsonnet-libs/k8s/pull/297. It didn't modify the kubernetes library but it modified lots of others. I'll have to think of a rule to allow the status conditionally