### PR TITLE
fix for object render and add clientId field for Azure Workload Identity

### DIFF
--- a/libs/secrets-store-csi-driver/config.jsonnet
+++ b/libs/secrets-store-csi-driver/config.jsonnet
@@ -1,5 +1,5 @@
 local config = import 'jsonnet/config.jsonnet';
-local versions = ['1.2.4'];
+local versions = ['1.2.4', '1.3.3'];
 local manifests = [
     'secrets-store.csi.x-k8s.io_secretproviderclasses.yaml',
 ];

--- a/libs/secrets-store-csi-driver/custom/secrets-store-csi-driver/secretProviderClass.libsonnet
+++ b/libs/secrets-store-csi-driver/custom/secrets-store-csi-driver/secretProviderClass.libsonnet
@@ -43,6 +43,8 @@ local patch = {
         withCloudName(cloudName):: { cloudName: cloudName },
         '#withTenantId':: d.fn(help='Helper-function to set attribute according to to specification (https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access#use-a-user-assigned-managed-identity)', args=[d.arg('withTenantId', d.T.string)]),
         withTenantId(tenantId):: { tenantId: tenantId },
+        '#withClientId':: d.fn(help='Helper-function to set attribute according to to specification (https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access#use-a-user-assigned-managed-identity)', args=[d.arg('withClientId', d.T.string)]),
+        withClientId(clientId):: { clientId: clientId },
 
         '#withObjects':: d.fn(help='Function to render objects-text. Takes an object-array e.g. [{objectName:"name",objectType:"secret"}] or an single object.', args=[d.arg('objects', d.T.array)]),
         withObjects(objects):: {
@@ -116,7 +118,7 @@ local patch = {
               userAssignedIdentityId=userAssignedIdentityId,
               keyvaultName=keyvaultName,
               tenantId=tenantId
-            ) + secrets_store_csi_driver.spec.parameters.withObjects(std.objectValues(objects)),
+            ) + secrets_store_csi_driver.spec.parameters.withObjects(objects),
           },
         }
         + if secretName != null then self.spec.withSecretObjects([


### PR DESCRIPTION
* Added 1.3.3 version of secret-store CRD (no changes from 1.2.4)
* added a `withClientId` function, as [Workload Identity](https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access#configure-workload-identity) is now out of Preview and in GA for AKS, and the field is need to use a Key Vault with Workload Identity
* Fixed an error in the `objects` rendering (it was expecting an object instead of an array, with the change it passes all render tests now)