### PR TITLE
feat: add google cloud sql operator

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -859,6 +859,46 @@
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
       "if": "steps.filter.outputs.workflows == 'true'"
       "run": "make libs/fluxcd"
+  "google-cloud-sql-proxy-operator":
+    "name": "Generate google-cloud-sql-proxy-operator Jsonnet library and docs"
+    "needs":
+    - "build"
+    - "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v2"
+    - "id": "filter"
+      "uses": "dorny/paths-filter@v2"
+      "with":
+        "filters": |
+          workflows:
+            - '.github/**'
+            - 'bin/**'
+            - 'Dockerfile'
+            - 'go.mod'
+            - 'go.sum'
+            - 'jsonnet/**'
+            - 'main.go'
+            - 'Makefile'
+            - 'pkg/**'
+            - 'scripts/**'
+            - 'tf/**'
+            - 'libs/google-cloud-sql-proxy-operator/**'
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "uses": "actions/download-artifact@v2"
+      "with":
+        "name": "docker-artifact"
+        "path": "artifacts"
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make load"
+    - "env":
+        "DIFF": "true"
+        "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+        "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
+        "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
+        "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
+      "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make libs/google-cloud-sql-proxy-operator"
   "grafana-agent":
     "name": "Generate grafana-agent Jsonnet library and docs"
     "needs":
@@ -1599,6 +1639,7 @@
     - "external-secrets"
     - "flagger"
     - "fluxcd"
+    - "google-cloud-sql-proxy-operator"
     - "grafana-agent"
     - "grafana-operator"
     - "harbor-operator"

--- a/libs/google-cloud-sql-proxy-operator/config.jsonnet
+++ b/libs/google-cloud-sql-proxy-operator/config.jsonnet
@@ -1,0 +1,20 @@
+local config = import 'jsonnet/config.jsonnet';
+local versions = ['0.5.0'];
+local manifests = ['cloud-sql-proxy-operator.yaml'];
+
+config.new(
+  name='google-cloud-sql-proxy-operator',
+  specs=[
+    {
+      output: std.join('.', std.split(version, '.')[:2]),
+      prefix: '^com\\.google\\.cloud\\.cloudsql\\..*',
+      localName: 'google-cloud-sql-proxy-operator',
+      crds: [
+        'https://raw.githubusercontent.com/GoogleCloudPlatform/cloud-sql-proxy-operator/v%s/installer/%s' %
+        [version, manifest]
+        for manifest in manifests
+      ],
+    }
+    for version in versions
+  ]
+)


### PR DESCRIPTION
Add the crd for the [google cloud sql operator](https://github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/tree/main). The operator helps configure and inject the gcp cloud sql operator for connecting to gcp mssql, mysql, and postgres database instances.
