### PR TITLE
Crossplane: Support 1.12 transforms

### DIFF
--- a/libs/crossplane/custom/crossplane/resource.libsonnet
+++ b/libs/crossplane/custom/crossplane/resource.libsonnet
@@ -326,9 +326,9 @@ local d = import 'doc-util/main.libsonnet';
                 patterns: patterns,
                 fallbackTo: fallbackTo,
               } + (
-                if fallbackTo == 'Input' then {} else {
+                if fallbackTo == 'Value' then {
                   fallbackValue: fallbackValue,
-                }
+                } else {}
               ),
             },
           ],


### PR DESCRIPTION
`fallbackTo: Input` and clamp math functions were added and these are helpers to make them easier to use

They are documented here: https://docs.crossplane.io/latest/concepts/composition/#transform-types