### PR TITLE
feat(edp-keycloak): Add edp-keycloak-operator CRDs@v1.15.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -739,6 +739,46 @@
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
       "if": "steps.filter.outputs.workflows == 'true'"
       "run": "make libs/eck-operator"
+  "edp-keycloak-operator":
+    "name": "Generate edp-keycloak-operator Jsonnet library and docs"
+    "needs":
+    - "build"
+    - "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v2"
+    - "id": "filter"
+      "uses": "dorny/paths-filter@v2"
+      "with":
+        "filters": |
+          workflows:
+            - '.github/**'
+            - 'bin/**'
+            - 'Dockerfile'
+            - 'go.mod'
+            - 'go.sum'
+            - 'jsonnet/**'
+            - 'main.go'
+            - 'Makefile'
+            - 'pkg/**'
+            - 'scripts/**'
+            - 'tf/**'
+            - 'libs/edp-keycloak-operator/**'
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "uses": "actions/download-artifact@v2"
+      "with":
+        "name": "docker-artifact"
+        "path": "artifacts"
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make load"
+    - "env":
+        "DIFF": "true"
+        "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+        "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
+        "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
+        "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
+      "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make libs/edp-keycloak-operator"
   "external-secrets":
     "name": "Generate external-secrets Jsonnet library and docs"
     "needs":
@@ -1676,6 +1716,7 @@
     - "contour"
     - "crossplane"
     - "eck-operator"
+    - "edp-keycloak-operator"
     - "external-secrets"
     - "flagger"
     - "fluxcd"

--- a/libs/edp-keycloak-operator/config.jsonnet
+++ b/libs/edp-keycloak-operator/config.jsonnet
@@ -1,0 +1,31 @@
+local config = import 'jsonnet/config.jsonnet';
+
+local versions = [
+  {output: '1.15.0', version:'v1.15.0'}
+];
+
+config.new(
+  name='edp-keycloak-operator',
+  specs=[
+    {
+      local url = 'https://raw.githubusercontent.com/epam/edp-keycloak-operator/%s/deploy-templates/crds/' % v.version,
+      output: v.output,
+      prefix: '^com\\.epam\\.edp\\..*',
+      crds: [
+        '%s/v1.edp.epam.com_keycloakauthflows.yaml' % url,
+        '%s/v1.edp.epam.com_keycloakclients.yaml' % url,
+        '%s/v1.edp.epam.com_keycloakclientscopes.yaml' % url,
+        '%s/v1.edp.epam.com_keycloakrealmcomponents.yaml' % url,
+        '%s/v1.edp.epam.com_keycloakrealmgroups.yaml' % url,
+        '%s/v1.edp.epam.com_keycloakrealmidentityproviders.yaml' % url,
+        '%s/v1.edp.epam.com_keycloakrealmrolebatches.yaml' % url,
+        '%s/v1.edp.epam.com_keycloakrealmroles.yaml' % url,
+        '%s/v1.edp.epam.com_keycloakrealms.yaml' % url,
+        '%s/v1.edp.epam.com_keycloakrealmusers.yaml' % url,
+        '%s/v1.edp.epam.com_keycloaks.yaml' % url,
+      ],
+      localName: 'edp-keycloak-operator',
+    }
+    for v in versions
+  ]
+)


### PR DESCRIPTION
Keycloak is a widely employed open source identity and access management server. Due to various reasons, Keycloak currently has no viable, feature-complete, first-party operator available. Fortunately, a good third-party operator is available from epam developer for their edp platform.

(https://github.com/epam/edp-keycloak-operator)

This commit adds a generated library for the crds of the newest version of the operator (v1.15.0)