### PR TITLE
crossplane: Fix `combineToComposite` to output the right type

### DIFF
--- a/libs/crossplane/custom/crossplane/resource.libsonnet
+++ b/libs/crossplane/custom/crossplane/resource.libsonnet
@@ -171,7 +171,7 @@ local d = import 'doc-util/main.libsonnet';
       },
 
       local combine(type, toFieldPath, fmtString, fromFieldPaths) = {
-        type: 'CombineFromComposite',
+        type: type,
         combine: {
           variables: [
             {


### PR DESCRIPTION
The `combine()` helper function was not using the provided type, it was accidentally hardcoding `CombineFromComposite`, which meant that `CombineToComposite` couldn't be used.