### PR TITLE
add Contour v1.25 and bump versions to the latest available tag

### DIFF
--- a/libs/contour/config.jsonnet
+++ b/libs/contour/config.jsonnet
@@ -1,5 +1,6 @@
 local config = import 'jsonnet/config.jsonnet';
 local versions = [
+  { version: '1.25', tag: 'v1.25.0'}
   { version: '1.24', tag: 'v1.24.4'},
   { version: '1.23', tag: 'v1.23.5'},
   { version: '1.22', tag: 'v1.22.6'},

--- a/libs/contour/config.jsonnet
+++ b/libs/contour/config.jsonnet
@@ -1,8 +1,8 @@
 local config = import 'jsonnet/config.jsonnet';
 local versions = [
-  { version: '1.24', tag: 'v1.24.2'},
-  { version: '1.23', tag: 'v1.23.2'},
-  { version: '1.22', tag: 'v1.22.2'},
+  { version: '1.24', tag: 'v1.24.4'},
+  { version: '1.23', tag: 'v1.23.5'},
+  { version: '1.22', tag: 'v1.22.6'},
   { version: '1.21', tag: 'v1.21.3'},
   { version: '1.20', tag: 'v1.20.2'},
   { version: '1.19', tag: 'v1.19.1'},


### PR DESCRIPTION
This PR adds Contour v1.25 and updates the existing versions with the latest available tag based on the [compatibility matrix. ](https://projectcontour.io/resources/compatibility-matrix/)