### PR TITLE
Add new minor versions for argo-cd

### DIFF
--- a/libs/argo-cd/config.jsonnet
+++ b/libs/argo-cd/config.jsonnet
@@ -1,5 +1,5 @@
 local config = import 'jsonnet/config.jsonnet';
-local versions = ['2.5.6', '2.4.11', '2.3.7', '2.2.12'];
+local versions = ['2.5.6', '2.4.11', '2.3.7', '2.2.12', '2.6.11', '2.7.6'];
 local manifests = ['application-crd.yaml', 'appproject-crd.yaml', 'applicationset-crd.yaml'];
 
 config.new(


### PR DESCRIPTION
Add versions `2.6.11` and `2.7.6` for argo-cd.