### PR TITLE
Add new prometheus-operator versions

### DIFF
--- a/libs/prometheus-operator/config.jsonnet
+++ b/libs/prometheus-operator/config.jsonnet
@@ -24,10 +24,10 @@ config.new(
         '%s/monitoring.coreos.com_alertmanagers.yaml' % url,
         '%s/monitoring.coreos.com_podmonitors.yaml' % url,
         '%s/monitoring.coreos.com_probes.yaml' % url,
-        '%s/monitoring.coreos.com_prometheusagents.yaml' % url,
+        '%s/monitoring.coreos.com_prometheusagents.yaml' % url,  // Added in 0.64
         '%s/monitoring.coreos.com_prometheuses.yaml' % url,
         '%s/monitoring.coreos.com_prometheusrules.yaml' % url,
-        '%s/monitoring.coreos.com_scrapeconfigs.yaml' % url,
+        '%s/monitoring.coreos.com_scrapeconfigs.yaml' % url,  // Added in 0.65
         '%s/monitoring.coreos.com_servicemonitors.yaml' % url,
         '%s/monitoring.coreos.com_thanosrulers.yaml' % url,
       ],

--- a/libs/prometheus-operator/config.jsonnet
+++ b/libs/prometheus-operator/config.jsonnet
@@ -1,12 +1,16 @@
 local config = import 'jsonnet/config.jsonnet';
 
 local versions = [
-    {output: '0.57', version: '0.57.0'},
-    {output: '0.58', version: '0.58.0'},
-    {output: '0.59', version: '0.59.2'},
-    {output: '0.60', version: '0.60.0'},
-    {output: '0.61', version: '0.61.1'},
-    {output: '0.62', version: '0.62.0'},
+  { output: '0.57', version: '0.57.0' },
+  { output: '0.58', version: '0.58.0' },
+  { output: '0.59', version: '0.59.2' },
+  { output: '0.60', version: '0.60.0' },
+  { output: '0.61', version: '0.61.1' },
+  { output: '0.62', version: '0.62.0' },
+  { output: '0.63', version: '0.63.0' },
+  { output: '0.64', version: '0.64.1' },
+  { output: '0.65', version: '0.65.2' },
+  { output: '0.66', version: '0.66.0' },
 ];
 
 config.new(
@@ -20,8 +24,10 @@ config.new(
         '%s/monitoring.coreos.com_alertmanagers.yaml' % url,
         '%s/monitoring.coreos.com_podmonitors.yaml' % url,
         '%s/monitoring.coreos.com_probes.yaml' % url,
+        '%s/monitoring.coreos.com_prometheusagents.yaml' % url,
         '%s/monitoring.coreos.com_prometheuses.yaml' % url,
         '%s/monitoring.coreos.com_prometheusrules.yaml' % url,
+        '%s/monitoring.coreos.com_scrapeconfigs.yaml' % url,
         '%s/monitoring.coreos.com_servicemonitors.yaml' % url,
         '%s/monitoring.coreos.com_thanosrulers.yaml' % url,
       ],


### PR DESCRIPTION
Adds all current minor versions of the prometheus-operator. This change also introduces two new CRDs, `prometheusagents` which was added in `0.64` and `scrapeconfigs` which was added in `0.65`. The current implementation in this repo handles `404` gracefully and simply does not generate for the new CRDs if they cannot be downloaded. I'm not sure if this is intended but since it works I opted to just include the new CRDs for all version. Let me know if you rather want me to build logic for this in the `config.jsonnet` file.