### PR TITLE
Bump CloudNative PG operator to v1.20.2

### DIFF
--- a/libs/cloudnative-pg/config.jsonnet
+++ b/libs/cloudnative-pg/config.jsonnet
@@ -4,8 +4,7 @@ local config = import 'jsonnet/config.jsonnet';
 
 local versions = [
   { version: '1.20.2' },
-  { version: '1.20.1' },
-  { version: '1.19.3' },
+  { version: '1.19.4' },
   { version: '1.18.5' },
   { version: '1.17.5' },
 ];

--- a/libs/cloudnative-pg/config.jsonnet
+++ b/libs/cloudnative-pg/config.jsonnet
@@ -3,6 +3,7 @@
 local config = import 'jsonnet/config.jsonnet';
 
 local versions = [
+  { version: '1.20.2' },
   { version: '1.20.1' },
   { version: '1.19.3' },
   { version: '1.18.5' },


### PR DESCRIPTION
This PR updates the library by adding the latest [v1.20.2](https://github.com/cloudnative-pg/cloudnative-pg/releases/tag/v1.20.2) release of the CloudNative PG operator.  It also includes all versions that are documented on the [CNPG documentation](https://cloudnative-pg.io/docs/).