### PR TITLE
Fix SecretProviderClass typo

### DIFF
--- a/libs/secrets-store-csi-driver/custom/secrets-store-csi-driver/secretProviderClass.libsonnet
+++ b/libs/secrets-store-csi-driver/custom/secrets-store-csi-driver/secretProviderClass.libsonnet
@@ -44,7 +44,7 @@ local patch = {
         '#withTenantId':: d.fn(help='Helper-function to set attribute according to to specification (https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access#use-a-user-assigned-managed-identity)', args=[d.arg('withTenantId', d.T.string)]),
         withTenantId(tenantId):: { tenantId: tenantId },
         '#withClientId':: d.fn(help='Helper-function to set attribute according to to specification (https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access#use-a-user-assigned-managed-identity)', args=[d.arg('withClientId', d.T.string)]),
-        withClientId(clientId):: { clientId: clientId },
+        withClientId(clientId):: { clientID: clientId },
 
         '#withObjects':: d.fn(help='Function to render objects-text. Takes an object-array e.g. [{objectName:"name",objectType:"secret"}] or an single object.', args=[d.arg('objects', d.T.array)]),
         withObjects(objects):: {


### PR DESCRIPTION
There is a tiny typo in the SecretProviderClass custom function "withClientId". The azure operator is specifically asking for `clientID` rather than `clientId`. 

Adding the wrong casing results in the following error:
```
secrets-store E0804 16:23:24.908716       1 reconciler.go:223] "failed to reconcile spc for pod" err="failed to rotate objects for pod ***, err: rpc error: code = Unknown desc = failed to mount objects, error: failed to create auth config, error: could not find clientid in secrets(map[])" spc="***" pod="***" controller="rotation"
```

The parameters are not defined in the CRD and therefore vulnerable to typos.