### PR TITLE
feat: Add 'runner scale sets' to actions-runner-controller

### DIFF
--- a/libs/actions-runner-controller/config.jsonnet
+++ b/libs/actions-runner-controller/config.jsonnet
@@ -1,28 +1,39 @@
 local config = import 'jsonnet/config.jsonnet';
 
 local versions = [
-  {output: '0.20', version: '0.20.3'},
-  {output: '0.21', version: '0.21.1'},
-  {output: '0.22', version: '0.22.0'},
-  {output: '0.23', version: '0.23.0'},
-  {output: '0.25', version: '0.25.0'},
-  {output: '0.26', version: '0.26.0'},
+  {output: '0.26', version: '0.26.0', legacy: true},
+  {output: '0.27', version: '0.27.4', legacy: true},
+  {output: '0.4', version: 'gha-runner-scale-set-0.4.0'},
 ];
 
 config.new(
   name='actions-runner-controller',
   specs=[
     {
-      local url = 'https://raw.githubusercontent.com/actions-runner-controller/actions-runner-controller/v%s/charts/actions-runner-controller/crds' % v.version,
+      local url =
+        if std.objectHas(v, 'legacy') then
+          'https://raw.githubusercontent.com/actions/actions-runner-controller/v%s/charts/actions-runner-controller/crds' % v.version
+        else
+          'https://raw.githubusercontent.com/actions/actions-runner-controller/%s/charts/gha-runner-scale-set-controller/crds' % v.version,
+
       output: v.output,
-      prefix: '^dev\\.summerwind\\.actions\\..*',
-      crds: [
-        '%s/actions.summerwind.dev_horizontalrunnerautoscalers.yaml' % url,
-        '%s/actions.summerwind.dev_runnerdeployments.yaml' % url,
-        '%s/actions.summerwind.dev_runnerreplicasets.yaml' % url,
-        '%s/actions.summerwind.dev_runners.yaml' % url,
-        '%s/actions.summerwind.dev_runnersets.yaml' % url,
-      ],
+      prefix: if std.objectHas(v, 'legacy') then '^dev\\.summerwind\\.actions\\..*' else '^com\\.github\\.actions\\..*',
+      crds:
+        if std.objectHas(v, 'legacy') then
+          [
+            '%s/actions.summerwind.dev_horizontalrunnerautoscalers.yaml' % url,
+            '%s/actions.summerwind.dev_runnerdeployments.yaml' % url,
+            '%s/actions.summerwind.dev_runnerreplicasets.yaml' % url,
+            '%s/actions.summerwind.dev_runners.yaml' % url,
+            '%s/actions.summerwind.dev_runnersets.yaml' % url,
+          ]
+        else
+          [
+            '%s/actions.github.com_autoscalinglisteners.yaml' % url,
+            '%s/actions.github.com_autoscalingrunnersets.yaml' % url,
+            '%s/actions.github.com_ephemeralrunners.yaml' % url,
+            '%s/actions.github.com_ephemeralrunnersets.yaml' % url,
+          ],
       localName: 'actions-runner-controller',
     }
     for v in versions


### PR DESCRIPTION
This one is a bit of an awkward update.
I'm not convinced this is the best way so happy to change it

The actions-runner-controller has been adopted by GitHub officially, along with a new 'mode'.
Which is actually a completely independent set of CRDs and controllers, but its all in the same repo.
It's not clear if there will be any significant further development on the 'legacy' mode either.

See the release announcement here: https://github.com/actions/actions-runner-controller/discussions/2775

I've removed all but the last 2 of the 'legacy' versions and just added the new CRDs as `0.4`.

We could make this a new lib, but as always, naming is the hardest bit. 
Given the new 'mode' is still called the Actions Runner Controller i'm not sure what else to call it and renaming the existing lib to 'actions-runner-controller-legacy' or something will break existing uses of the lib.