### PR TITLE
Crossplane: 1.13 + various provider bumps

### DIFF
--- a/libs/crossplane/config.jsonnet
+++ b/libs/crossplane/config.jsonnet
@@ -6,6 +6,13 @@ config.new(
     // Crossplane itself
     // Release support table: https://github.com/crossplane/crossplane#releases
     {
+      output: 'crossplane/1.13',
+      prefix: '^io\\.crossplane\\.(pkg|apiextensions)\\..*',
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane/crossplane@v1.13.0'],
+      localName: 'crossplane',
+      patchDir: 'custom/crossplane',
+    },
+    {
       output: 'crossplane/1.12',
       prefix: '^io\\.crossplane\\.(pkg|apiextensions)\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/crossplane/crossplane@v1.12.0'],
@@ -61,10 +68,22 @@ config.new(
       localName: 'crossplane_azure',
     },
     {
+      output: 'provider-sql/0.7',
+      prefix: '^io\\.crossplane\\.sql\\..*',
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-sql@v0.7.0'],
+      localName: 'crossplane_sql',
+    },
+    {
       output: 'provider-sql/0.6',
       prefix: '^io\\.crossplane\\.sql\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-sql@v0.6.0'],
       localName: 'crossplane_sql',
+    },
+    {
+      output: 'provider-kubernetes/0.9',
+      prefix: '^io\\.crossplane\\.kubernetes\\..*',
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-kubernetes@v0.9.0'],
+      localName: 'crossplane_kubernetes',
     },
     {
       output: 'provider-kubernetes/0.6',
@@ -108,6 +127,12 @@ config.new(
     // Upbound official providers
     // https://marketplace.upbound.io/
     {
+      output: 'upbound-provider-aws/0.40',
+      prefix: '^io\\.upbound\\.aws\\..*',
+      crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-aws@v0.40.0'],
+      localName: 'upbound_aws',
+    },
+    {
       output: 'upbound-provider-aws/0.31',
       prefix: '^io\\.upbound\\.aws\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-aws@v0.31.0'],
@@ -120,16 +145,34 @@ config.new(
       localName: 'upbound_azure',
     },
     {
+      output: 'upbound-provider-azuread/0.11',
+      prefix: '^io\\.upbound\\.azuread\\..*',
+      crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-azuread@v0.11.0'],
+      localName: 'upbound_azuread',
+    },
+    {
       output: 'upbound-provider-azuread/0.5',
       prefix: '^io\\.upbound\\.azuread\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-azuread@v0.5.0'],
       localName: 'upbound_azuread',
     },
     {
+      output: 'upbound-provider-gcp/0.36',
+      prefix: '^io\\.upbound\\.gcp\\..*',
+      crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-gcp@v0.36.0'],
+      localName: 'upbound_gcp',
+    },
+    {
       output: 'upbound-provider-gcp/0.29',
       prefix: '^io\\.upbound\\.gcp\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-gcp@v0.29.0'],
       localName: 'upbound_gcp',
+    },
+    {
+      output: 'provider-terraform/0.10',
+      prefix: '^io\\.upbound\\.tf\\..*',
+      crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-terraform@v0.10.0'],
+      localName: 'upbound_terraform',
     },
     {
       output: 'provider-terraform/0.5',


### PR DESCRIPTION
Bumps Crossplane itself to 1.13 (latest), and various of the providers.

I wanted to do `azure` too, but I got an error `mapping values not allowed in this context` or something like that, will make a separate PR for that one and we can take a look.