### PR TITLE
feat: add argo-rollouts v1.6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,6 +120,46 @@
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
       "if": "steps.filter.outputs.workflows == 'true'"
       "run": "make libs/argo-cd"
+  "argo-rollouts":
+    "name": "Generate argo-rollouts Jsonnet library and docs"
+    "needs":
+    - "build"
+    - "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v2"
+    - "id": "filter"
+      "uses": "dorny/paths-filter@v2"
+      "with":
+        "filters": |
+          workflows:
+            - '.github/**'
+            - 'bin/**'
+            - 'Dockerfile'
+            - 'go.mod'
+            - 'go.sum'
+            - 'jsonnet/**'
+            - 'main.go'
+            - 'Makefile'
+            - 'pkg/**'
+            - 'scripts/**'
+            - 'tf/**'
+            - 'libs/argo-rollouts/**'
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "uses": "actions/download-artifact@v2"
+      "with":
+        "name": "docker-artifact"
+        "path": "artifacts"
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make load"
+    - "env":
+        "DIFF": "true"
+        "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+        "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
+        "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
+        "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
+      "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make libs/argo-rollouts"
   "argo-workflows":
     "name": "Generate argo-workflows Jsonnet library and docs"
     "needs":
@@ -1581,6 +1621,7 @@
     - "actions-runner-controller"
     - "aiven"
     - "argo-cd"
+    - "argo-rollouts"
     - "argo-workflows"
     - "aws-load-balancer-controller"
     - "banzai-logging"

--- a/libs/argo-rollouts/config.jsonnet
+++ b/libs/argo-rollouts/config.jsonnet
@@ -1,0 +1,28 @@
+local config = import 'jsonnet/config.jsonnet';
+local manifests = [
+  'analysis-run-crd.yaml',
+  'analysis-template-crd.yaml',
+  'cluster-analysis-template-crd.yaml',
+  'experiment-crd.yaml',
+  'rollout-crd.yaml',
+];
+local versions = [
+  '1.6.0'
+];
+
+config.new(
+  name='argo-rollouts',
+  specs=[
+    {
+      output: std.join('.', std.split(version, '.')[:2]),
+      prefix: '^io\\.argoproj\\..*',
+      localName: 'argo_rollouts',
+      crds: [
+        'https://raw.githubusercontent.com/argoproj/argo-rollouts/v%s/manifests/crds/%s' %
+        [version, manifest]
+        for manifest in manifests
+      ],
+    }
+    for version in versions
+  ]
+)


### PR DESCRIPTION
Generate libsonnet for the argo-rollouts [custom resource
definitions](https://github.com/argoproj/argo-rollouts/tree/v1.6.0/manifests/crds).

[Argo Rollouts](https://argo-rollouts.readthedocs.io/en/stable/) is a progressive
delivery controller that supports advanced deployment patterns such as
blue-green, canary, canary analysis, experimentation, and progressive
delivery for kubernetes.
