### PR TITLE
Crossplane: Upgrade Grafana + Clear out old versions

### DIFF
--- a/libs/crossplane/config.jsonnet
+++ b/libs/crossplane/config.jsonnet
@@ -19,34 +19,6 @@ config.new(
       localName: 'crossplane',
       patchDir: 'custom/crossplane',
     },
-    {
-      output: 'crossplane/1.11',
-      prefix: '^io\\.crossplane\\.(pkg|apiextensions)\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/crossplane@v1.11.2'],
-      localName: 'crossplane',
-      patchDir: 'custom/crossplane',
-    },
-    {
-      output: 'crossplane/1.10',
-      prefix: '^io\\.crossplane\\.(pkg|apiextensions)\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/crossplane@v1.10.2'],
-      localName: 'crossplane',
-      patchDir: 'custom/crossplane',
-    },
-    {
-      output: 'crossplane/1.9',
-      prefix: '^io\\.crossplane\\.(pkg|apiextensions)\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/crossplane@v1.9.0'],
-      localName: 'crossplane',
-      patchDir: 'custom/crossplane',
-    },
-    {
-      output: 'crossplane/1.8',
-      prefix: '^io\\.crossplane\\.(pkg|apiextensions)\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane/crossplane@v1.8.0'],
-      localName: 'crossplane',
-      patchDir: 'custom/crossplane',
-    },
 
     // crossplane-contrib
     {
@@ -74,21 +46,9 @@ config.new(
       localName: 'crossplane_sql',
     },
     {
-      output: 'provider-sql/0.6',
-      prefix: '^io\\.crossplane\\.sql\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-sql@v0.6.0'],
-      localName: 'crossplane_sql',
-    },
-    {
       output: 'provider-kubernetes/0.9',
       prefix: '^io\\.crossplane\\.kubernetes\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-kubernetes@v0.9.0'],
-      localName: 'crossplane_kubernetes',
-    },
-    {
-      output: 'provider-kubernetes/0.6',
-      prefix: '^io\\.crossplane\\.kubernetes\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-kubernetes@v0.6.0'],
       localName: 'crossplane_kubernetes',
     },
     {
@@ -104,12 +64,6 @@ config.new(
       localName: 'crossplane_jet_mongodbatlas',
     },
     {
-      output: 'provider-nop/0.1.1',
-      prefix: '^io\\.crossplane\\.nop\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-nop@v0.1.1'],
-      localName: 'crossplane_nop',
-    },
-    {
       output: 'provider-nop/0.2.0',
       prefix: '^io\\.crossplane\\.nop\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-nop@v0.2.0'],
@@ -118,9 +72,9 @@ config.new(
 
     // Grafana
     {
-      output: 'provider-grafana/0.5',
+      output: 'provider-grafana/0.7',
       prefix: '^io\\.crossplane\\.grafana\\..*',
-      crds: ['https://github.com/grafana/crossplane-provider-grafana/releases/download/v0.5.0/crds.yaml'],
+      crds: ['https://github.com/grafana/crossplane-provider-grafana/releases/download/v0.7.0/crds.yaml'],
       localName: 'crossplane_grafana',
     },
 
@@ -130,12 +84,6 @@ config.new(
       output: 'upbound-provider-aws/0.40',
       prefix: '^io\\.upbound\\.aws\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-aws@v0.40.0'],
-      localName: 'upbound_aws',
-    },
-    {
-      output: 'upbound-provider-aws/0.31',
-      prefix: '^io\\.upbound\\.aws\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-aws@v0.31.0'],
       localName: 'upbound_aws',
     },
     {
@@ -151,33 +99,15 @@ config.new(
       localName: 'upbound_azuread',
     },
     {
-      output: 'upbound-provider-azuread/0.5',
-      prefix: '^io\\.upbound\\.azuread\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-azuread@v0.5.0'],
-      localName: 'upbound_azuread',
-    },
-    {
       output: 'upbound-provider-gcp/0.36',
       prefix: '^io\\.upbound\\.gcp\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-gcp@v0.36.0'],
       localName: 'upbound_gcp',
     },
     {
-      output: 'upbound-provider-gcp/0.29',
-      prefix: '^io\\.upbound\\.gcp\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-gcp@v0.29.0'],
-      localName: 'upbound_gcp',
-    },
-    {
       output: 'provider-terraform/0.10',
       prefix: '^io\\.upbound\\.tf\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-terraform@v0.10.0'],
-      localName: 'upbound_terraform',
-    },
-    {
-      output: 'provider-terraform/0.5',
-      prefix: '^io\\.upbound\\.tf\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-terraform@v0.5.0'],
       localName: 'upbound_terraform',
     },
   ]


### PR DESCRIPTION
They can still be pulled by jsonnet-bundler by pointing to an old changeset 
Generating the Crossplane provider libs is pretty long