### PR TITLE
configuration to build 2.1.X libs for fluxcd

### DIFF
--- a/libs/fluxcd/config.jsonnet
+++ b/libs/fluxcd/config.jsonnet
@@ -4,20 +4,6 @@ config.new(
   name='fluxcd',
   specs=[
     {
-      // CRDs retrieved from https://github.com/fluxcd/flux2/blob/v2.0.1/manifests/crds/kustomization.yaml
-      output: '2.0.1',
-      prefix: '^io\\.fluxcd\\.toolkit\\..*',
-      crds: [
-        'https://github.com/fluxcd/source-controller/releases/download/v1.0.1/source-controller.crds.yaml',
-        'https://github.com/fluxcd/kustomize-controller/releases/download/v1.0.1/kustomize-controller.crds.yaml',
-        'https://github.com/fluxcd/helm-controller/releases/download/v0.35.0/helm-controller.crds.yaml',
-        'https://github.com/fluxcd/notification-controller/releases/download/v1.0.0/notification-controller.crds.yaml',
-        'https://github.com/fluxcd/image-reflector-controller/releases/download/v0.29.1/image-reflector-controller.crds.yaml',
-        'https://github.com/fluxcd/image-automation-controller/releases/download/v0.35.0/image-automation-controller.crds.yaml',
-      ],
-      localName: 'fluxcd',
-    },
-    {
       // CRDs retrieved from https://github.com/fluxcd/flux2/blob/v0.30.2/manifests/crds/kustomization.yaml
       output: '0.30.2',
       prefix: '^io\\.fluxcd\\.toolkit\\..*',
@@ -154,6 +140,62 @@ config.new(
         'https://github.com/fluxcd/notification-controller/releases/download/v0.33.0/notification-controller.crds.yaml',
         'https://github.com/fluxcd/image-reflector-controller/releases/download/v0.26.0/image-reflector-controller.crds.yaml',
         'https://github.com/fluxcd/image-automation-controller/releases/download/v0.31.0/image-automation-controller.crds.yaml',
+      ],
+      localName: 'fluxcd',
+    },
+    {
+      // CRDs retrieved from https://github.com/fluxcd/flux2/blob/v2.0.1/manifests/crds/kustomization.yaml
+      output: '2.0.1',
+      prefix: '^io\\.fluxcd\\.toolkit\\..*',
+      crds: [
+        'https://github.com/fluxcd/source-controller/releases/download/v1.0.1/source-controller.crds.yaml',
+        'https://github.com/fluxcd/kustomize-controller/releases/download/v1.0.1/kustomize-controller.crds.yaml',
+        'https://github.com/fluxcd/helm-controller/releases/download/v0.35.0/helm-controller.crds.yaml',
+        'https://github.com/fluxcd/notification-controller/releases/download/v1.0.0/notification-controller.crds.yaml',
+        'https://github.com/fluxcd/image-reflector-controller/releases/download/v0.29.1/image-reflector-controller.crds.yaml',
+        'https://github.com/fluxcd/image-automation-controller/releases/download/v0.35.0/image-automation-controller.crds.yaml',
+      ],
+      localName: 'fluxcd',
+    },
+    {
+      // CRDs retrieved from https://github.com/fluxcd/flux2/blob/v2.1.0/manifests/crds/kustomization.yaml
+      output: '2.1.0',
+      prefix: '^io\\.fluxcd\\.toolkit\\..*',
+      crds: [
+        'https://github.com/fluxcd/source-controller/releases/download/v1.1.0/source-controller.crds.yaml',
+        'https://github.com/fluxcd/kustomize-controller/releases/download/v1.1.0/kustomize-controller.crds.yaml',
+        'https://github.com/fluxcd/helm-controller/releases/download/v0.36.0/helm-controller.crds.yaml',
+        'https://github.com/fluxcd/notification-controller/releases/download/v1.1.0/notification-controller.crds.yaml',
+        'https://github.com/fluxcd/image-reflector-controller/releases/download/v0.30.1/image-reflector-controller.crds.yaml',
+        'https://github.com/fluxcd/image-automation-controller/releases/download/v0.36.0/image-automation-controller.crds.yaml'
+      ],
+      localName: 'fluxcd',
+    },
+    {
+      // CRDs retrieved from https://github.com/fluxcd/flux2/blob/v2.1.1/manifests/crds/kustomization.yaml
+      output: '2.1.1',
+      prefix: '^io\\.fluxcd\\.toolkit\\..*',
+      crds: [
+        'https://github.com/fluxcd/source-controller/releases/download/v1.1.1/source-controller.crds.yaml',
+        'https://github.com/fluxcd/kustomize-controller/releases/download/v1.1.0/kustomize-controller.crds.yaml',
+        'https://github.com/fluxcd/helm-controller/releases/download/v0.36.1/helm-controller.crds.yaml',
+        'https://github.com/fluxcd/notification-controller/releases/download/v1.1.0/notification-controller.crds.yaml',
+        'https://github.com/fluxcd/image-reflector-controller/releases/download/v0.30.1/image-reflector-controller.crds.yaml',
+        'https://github.com/fluxcd/image-automation-controller/releases/download/v0.36.1/image-automation-controller.crds.yaml',
+      ],
+      localName: 'fluxcd',
+    },
+    {
+      // CRDs retrieved from https://github.com/fluxcd/flux2/blob/v2.1.2/manifests/crds/kustomization.yaml
+      output: '2.1.2',
+      prefix: '^io\\.fluxcd\\.toolkit\\..*',
+      crds: [
+        'https://github.com/fluxcd/source-controller/releases/download/v1.1.2/source-controller.crds.yaml',
+        'https://github.com/fluxcd/kustomize-controller/releases/download/v1.1.1/kustomize-controller.crds.yaml',
+        'https://github.com/fluxcd/helm-controller/releases/download/v0.36.2/helm-controller.crds.yaml',
+        'https://github.com/fluxcd/notification-controller/releases/download/v1.1.0/notification-controller.crds.yaml',
+        'https://github.com/fluxcd/image-reflector-controller/releases/download/v0.30.0/image-reflector-controller.crds.yaml',
+        'https://github.com/fluxcd/image-automation-controller/releases/download/v0.36.1/image-automation-controller.crds.yaml',
       ],
       localName: 'fluxcd',
     },


### PR DESCRIPTION
I tried to add newer versions of the fluxcd library, however the build process errors out:
```
Generating '2.0.1' from 'https://github.com/fluxcd/image-reflector-controller/releases/download/v0.29.1/image-reflector-controller.crds.yaml, ^io\.fluxcd\.toolkit\..*'
Generating '2.0.1' from 'https://github.com/fluxcd/image-automation-controller/releases/download/v0.35.0/image-automation-controller.crds.yaml, ^io\.fluxcd\.toolkit\..*'
Generating '2.1.0' from 'https://github.com/fluxcd/source-controller/releases/download/v1.1.0/source-controller.crds.yaml, ^io\.fluxcd\.toolkit\..*'
Generating '2.1.0' from 'https://github.com/fluxcd/kustomize-controller/releases/download/v1.1.0/kustomize-controller.crds.yaml, ^io\.fluxcd\.toolkit\..*'
Generating '2.1.0' from 'https://github.com/fluxcd/helm-controller/releases/download/v0.36.0/helm-controller.crds.yaml, ^io\.fluxcd\.toolkit\..*'
Generating '2.1.0' from 'https://github.com/fluxcd/notification-controller/releases/download/v1.1.0/notification-controller.crds.yaml, ^io\.fluxcd\.toolkit\..*'
Generating '2.1.0' from 'https://github.com/fluxcd/image-reflector-controller/releases/download/v0.30.1/image-reflector-controller.crds.yaml, ^io\.fluxcd\.toolkit\..*'
error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type v1.CustomResourceDefinition
```

I'm not a golang programmer, so I'm trying my best here. The diff between `v0.35.0` and `v0.36.0` is 
```diff
diff -u /Users/carl.thuringer/dev/carl-reverb/k8s/crd-0-35-0.yaml /Users/carl.thuringer/dev/carl-reverb/k8s/crd-0-36-0.yaml
--- /Users/carl.thuringer/dev/carl-reverb/k8s/crd-0-35-0.yaml	2023-10-24 10:59:19
+++ /Users/carl.thuringer/dev/carl-reverb/k8s/crd-0-36-0.yaml	2023-10-24 10:59:31
@@ -134,8 +134,20 @@
                           to the branch named. The branch is created using `.spec.checkout.branch`
                           as the starting point, if it doesn't already exist.
                         type: string
-                    required:
-                    - branch
+                      options:
+                        additionalProperties:
+                          type: string
+                        description: 'Options specifies the push options that are
+                          sent to the Git server when performing a push operation.
+                          For details, see: https://git-scm.com/docs/git-push#Documentation/git-push.txt---push-optionltoptiongt'
+                        type: object
+                      refspec:
+                        description: 'Refspec specifies the Git Refspec to use for
+                          a push operation. If both Branch and Refspec are provided,
+                          then the commit is pushed to the branch and also using the
+                          specified refspec. For more details about Git Refspecs,
+                          see: https://git-scm.com/book/en/v2/Git-Internals-The-Refspec'
+                        type: string
                     type: object
                 required:
                 - commit

Diff finished.  Tue Oct 24 11:08:04 2023
```
The only thing that stands out is the inclusion of `additionalProperties`. I dug through `apiextensions-apiserver@v0.27.3` and found:

```golang
	AdditionalProperties *JSONSchemaPropsOrBool     `json:"additionalProperties,omitempty" protobuf:"bytes,30,opt,name=additionalProperties"`
```
https://github.com/kubernetes/apiextensions-apiserver/blob/e3982fff219146fa2e37d8097ddf360f72b64841/pkg/apis/apiextensions/v1/types_jsonschema.go#L81

This `JSONSchemaPropsOrBool` seems to be the thing which it is having trouble unmarshaling because that type doesn't have a `json:` annotation 

```golang
type JSONSchemaPropsOrBool struct {
	Allows bool             `protobuf:"varint,1,opt,name=allows"`
	Schema *JSONSchemaProps `protobuf:"bytes,2,opt,name=schema"`
}
```

https://github.com/kubernetes/apiextensions-apiserver/blob/e3982fff219146fa2e37d8097ddf360f72b64841/pkg/apis/apiextensions/v1/types_jsonschema.go#L296-L299

So, apparently this is a problem for `kubernetes-apiextensions/apiserver`, which is upstream, but does this mean that `jsonnet-libs` cannot support generating libraries for any CRD which uses `additionalProperties` in the CRD?
Therefore it's only possible to support flux going forward by switching to the OpenAPI schemas, which they fortunately generate with their releases however they publish them in a gzip bundle, not as an endpoint, which can't be directly consumed by the SwaggerLoader.

Any advice?