### PR TITLE
bump CNPG to v1.21.1

### DIFF
--- a/libs/cloudnative-pg/config.jsonnet
+++ b/libs/cloudnative-pg/config.jsonnet
@@ -3,11 +3,10 @@
 local config = import 'jsonnet/config.jsonnet';
 
 local versions = [
-  { version: '1.21.0' },
-  { version: '1.20.2' },
-  { version: '1.19.4' },
-  { version: '1.18.5' },
-  { version: '1.17.5' },
+  { version: '1.21.1' }, // released on November 3, 2023
+  { version: '1.20.4' }, // released on November 3, 2023
+  { version: '1.19.6' }, // released on November 3, 2023
+  { version: '1.18.5' }  // released on June 12, 2023
 ];
 
 config.new(


### PR DESCRIPTION
This PR bumps the CNPG to the latest v1.21.0 and updates other major versions. 