### PR TITLE
chore(grafana-operator): add 5.4 version

### DIFF
--- a/libs/grafana-operator/config.jsonnet
+++ b/libs/grafana-operator/config.jsonnet
@@ -12,6 +12,7 @@ local versions = [
   { output: '4.9', version: '4.9.0' },
   { output: '4.10', version: '4.10.1' },
   { output: '5.0', version: '5.0.2' },
+  { output: '5.4', version: '5.4.2' },
 ];
 
 config.new(


### PR DESCRIPTION
`grafanadashboard` CRD is invalid in versions v5.1, v5.2 and v5.3, so I had to skip these (more info in the PR https://github.com/jsonnet-libs/k8s/pull/336). 

The issue was fixed in https://github.com/grafana-operator/grafana-operator/pull/1199 so we can safely add v5.4