### PR TITLE
Allow loading CRD data from local file

### DIFF
--- a/pkg/swagger/load.go
+++ b/pkg/swagger/load.go
@@ -3,22 +3,39 @@ package swagger
 import (
 	"io/ioutil"
 	"net/http"
+    "net/url"
 )
 
 type Loader interface {
 	Load([]byte) (Definitions, error)
 }
 
-func Load(loader Loader, url string) (Definitions, error) {
-	r, err := http.Get(url)
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return nil, err
-	}
-
+func Load(loader Loader, uri string) (Definitions, error) {
+	var data []byte
+	var err error
+    if isURL(uri) {
+        r, err := http.Get(uri)
+        if err != nil {
+            return nil, err
+        }
+		data, err = ioutil.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+    } else {
+		data, err = ioutil.ReadFile(uri)
+		if err != nil {
+			return nil, err
+		}
+    }
 	return loader.Load(data)
+}
+
+func isURL(uri string) bool {
+	endpoint, err := url.Parse(uri)
+	if err != nil {
+		return false
+	}
+
+	return len(endpoint.Scheme) > 0
 }


### PR DESCRIPTION
Allow loading the CRD data from a local file instead of a URL. If the URI passed is a URL, then use the original mechanism, but if not then try to interpret it as a local file instead.

This is useful if you want to use k8s-gen with libraries that do not make the CRDs available via a simple endpoint, and which require downloading and processing locally before passing to k8s-gen.