### PR TITLE
fix: add missing value to Crossplane resource patch

### DIFF
--- a/libs/crossplane/custom/crossplane/resource.libsonnet
+++ b/libs/crossplane/custom/crossplane/resource.libsonnet
@@ -99,6 +99,7 @@ local d = import 'doc-util/main.libsonnet';
               type: 'string',
               string: {
                 fmt: '%s-' + suffix,
+                type: 'Format',
               },
             }],
           },


### PR DESCRIPTION
To avoid diffs in ArgoCD, this commit adds the transform string type explicitly

![image](https://github.com/jsonnet-libs/k8s/assets/634680/22810e8c-248a-4dea-9a63-05142a1b459b)
