### PR TITLE
Emissary ingress libraries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -859,6 +859,46 @@
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
       "if": "steps.filter.outputs.workflows == 'true'"
       "run": "make libs/edp-keycloak-operator"
+  "emissary":
+    "name": "Generate emissary Jsonnet library and docs"
+    "needs":
+    - "build"
+    - "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v3"
+    - "id": "filter"
+      "uses": "dorny/paths-filter@v2"
+      "with":
+        "filters": |
+          workflows:
+            - '.github/**'
+            - 'bin/**'
+            - 'Dockerfile'
+            - 'go.mod'
+            - 'go.sum'
+            - 'jsonnet/**'
+            - 'main.go'
+            - 'Makefile'
+            - 'pkg/**'
+            - 'scripts/**'
+            - 'tf/**'
+            - 'libs/emissary/**'
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "uses": "actions/download-artifact@v2"
+      "with":
+        "name": "docker-artifact"
+        "path": "artifacts"
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make load"
+    - "env":
+        "DIFF": "true"
+        "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+        "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
+        "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
+        "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
+      "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make libs/emissary"
   "external-dns":
     "name": "Generate external-dns Jsonnet library and docs"
     "needs":
@@ -1659,6 +1699,46 @@
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
       "if": "steps.filter.outputs.workflows == 'true'"
       "run": "make libs/litmus-chaos"
+  "mysql-operator":
+    "name": "Generate mysql-operator Jsonnet library and docs"
+    "needs":
+    - "build"
+    - "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v3"
+    - "id": "filter"
+      "uses": "dorny/paths-filter@v2"
+      "with":
+        "filters": |
+          workflows:
+            - '.github/**'
+            - 'bin/**'
+            - 'Dockerfile'
+            - 'go.mod'
+            - 'go.sum'
+            - 'jsonnet/**'
+            - 'main.go'
+            - 'Makefile'
+            - 'pkg/**'
+            - 'scripts/**'
+            - 'tf/**'
+            - 'libs/mysql-operator/**'
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "uses": "actions/download-artifact@v2"
+      "with":
+        "name": "docker-artifact"
+        "path": "artifacts"
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make load"
+    - "env":
+        "DIFF": "true"
+        "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+        "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
+        "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
+        "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
+      "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make libs/mysql-operator"
   "openshift":
     "name": "Generate openshift Jsonnet library and docs"
     "needs":
@@ -1879,6 +1959,7 @@
     - "crossplane"
     - "eck-operator"
     - "edp-keycloak-operator"
+    - "emissary"
     - "external-dns"
     - "external-secrets"
     - "flagger"
@@ -1899,6 +1980,7 @@
     - "kubevela"
     - "kyverno"
     - "litmus-chaos"
+    - "mysql-operator"
     - "openshift"
     - "prometheus-operator"
     - "rabbitmq"

--- a/libs/emissary/config.jsonnet
+++ b/libs/emissary/config.jsonnet
@@ -1,0 +1,20 @@
+local config = import 'jsonnet/config.jsonnet';
+
+local versions = [
+  { version: '3.7', tag: '3.7.2' },
+  { version: '3.8', tag: '3.8.2' },
+  { version: '3.9', tag: '3.9.1' },
+];
+
+config.new(
+  name='emissary',
+  specs=[
+    {
+      output: v.version,
+      prefix: '^io\\.getambassador\\..*',
+      crds: ['https://app.getambassador.io/yaml/emissary/%s/emissary-crds.yaml' % v.tag],
+      localName: 'emissary',
+    }
+    for v in versions
+  ]
+)


### PR DESCRIPTION
This adds libraries for the [Emissary ingress](https://github.com/emissary-ingress/emissary) (previously named Ambassador in CNCF incubation), and is built on Envoy.