### PR TITLE
chore: Add v1.0.0 for Kubernetes Gateway API

### DIFF
--- a/libs/gateway-api/config.jsonnet
+++ b/libs/gateway-api/config.jsonnet
@@ -5,7 +5,7 @@ config.new(
   name='gateway-api',
   specs=[
     {
-      output: std.join('.', std.split(version, '.')[:2]),
+      output: version,
       prefix: '^io\\.k8s\\.networking\\.gateway\\..*',
 	  crds: ['https://github.com/kubernetes-sigs/gateway-api/releases/download/%s/standard-install.yaml' % version],
       localName: 'gateway-api',

--- a/libs/gateway-api/config.jsonnet
+++ b/libs/gateway-api/config.jsonnet
@@ -7,9 +7,9 @@ config.new(
     {
       output: version,
       prefix: '^io\\.k8s\\.networking\\.gateway\\..*',
-	  crds: ['https://github.com/kubernetes-sigs/gateway-api/releases/download/%s/standard-install.yaml' % version],
+      crds: ['https://github.com/kubernetes-sigs/gateway-api/releases/download/%s/standard-install.yaml' % version],
       localName: 'gateway-api',
-    },
+    }
     for version in versions
   ]
 )

--- a/libs/gateway-api/config.jsonnet
+++ b/libs/gateway-api/config.jsonnet
@@ -1,13 +1,15 @@
 local config = import 'jsonnet/config.jsonnet';
+local versions = ['v0.7.1', 'v1.0.0'];
 
 config.new(
   name='gateway-api',
   specs=[
     {
-      output: 'v0.7.1',
+      output: std.join('.', std.split(version, '.')[:2]),
       prefix: '^io\\.k8s\\.networking\\.gateway\\..*',
-	  crds: ['https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.7.1/standard-install.yaml'],
+	  crds: ['https://github.com/kubernetes-sigs/gateway-api/releases/download/%s/standard-install.yaml' % version],
       localName: 'gateway-api',
     },
+    for version in versions
   ]
 )


### PR DESCRIPTION
### Context

Kubernetes Gateway API has graduated to GA and v1.0.0 is now available.

### Intent

Add v1.0.0 version CRDs to [gateway-api-libsonnet](https://github.com/jsonnet-libs/gateway-api-libsonnet) via this repo (`jsonnet-libs/k8s`).