### PR TITLE
style: update mkdocs config and css

### DIFF
--- a/jsonnet/config.jsonnet
+++ b/jsonnet/config.jsonnet
@@ -60,9 +60,7 @@
     'skel/mkdocs.yml': std.manifestYamlDoc(this.mkdocs_config, true),
 
     'skel/.github/workflows/main.yml': std.manifestYamlDoc(this.mkdocs_github_action, true),
-    'skel/docs/stylesheets/extra.css': |||
-      .md-nav__link:first-letter { text-transform: lowercase; }
-    |||,
+    'skel/docs/stylesheets/extra.css': importstr 'files/mkdocs.css',
 
     'skel/requirements.txt': |||
       # mkdocs
@@ -76,6 +74,9 @@
 
       # Include the theme
       mkdocs-material>=7.1.6
+
+      # Deal with list indent of 2 spaces
+      mdx-truly-sane-lists>=1.3
     |||,
   },
 }

--- a/jsonnet/files/mkdocs.css
+++ b/jsonnet/files/mkdocs.css
@@ -1,0 +1,48 @@
+/* Menu */
+/* Decapitalize menu items, Mkdocs capilizes by default and can't be configured */
+nav nav .md-nav__link .md-ellipsis::first-letter { text-transform: lowercase }
+
+/* TOC */
+/* Don't wrap TOC links with spaces */
+.md-sidebar--secondary .md-nav__item { white-space: nowrap }
+/* Scroll horizontal to make them accessible */
+.md-sidebar--secondary .md-sidebar__scrollwrap { overflow-x: auto }
+
+/* Code */
+/* Make codeblocks stand out */
+.md-typeset pre>code { border-left: 0.2rem solid var(--md-accent-fg-color) }
+
+/* Headings */
+/* Hide headings for functions but don't remove them, they function as deeplink targets */
+h2[id^="fn-"],
+h3[id^="fn-"],
+h4[id^="fn-"],
+h5[id^="fn-"],
+h6[id^="fn-"],
+h7[id^="fn-"],
+h8[id^="fn-"],
+h9[id^="fn-"] {
+  visibility: hidden;
+  width: 0;
+  height: 0;
+  padding: 0;
+  margin: 0;
+}
+
+/* Parameters */
+/* Format 'PARAMETERS' after highlight (div.highlight) */
+/* Match first paragraph (p) but only if it is followed by an unsorted list (ul) */
+article.md-content__inner.md-typeset div.highlight+p:has(+ul) {
+  padding-left: 1em;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+/* Match first unsorted list (ul) after paragraph (p) */
+article.md-content__inner.md-typeset div.highlight+p+ul {
+  padding-left: 1em;
+  margin-top:0;
+}
+article.md-content__inner.md-typeset div.highlight+p+ul li {
+  margin-top: 0;
+  margin-bottom: 0;
+}

--- a/jsonnet/mkdocs.jsonnet
+++ b/jsonnet/mkdocs.jsonnet
@@ -8,6 +8,10 @@
     extra_css: ['stylesheets/extra.css'],
     theme: {
       name: 'material',
+      features: [
+        'navigation.tabs',
+        'navigation.indexes',
+      ],
       palette: [
         {
           scheme: 'default',
@@ -34,9 +38,6 @@
     plugins: [
       {
         search: {
-          indexing: 'titles',
-          prebuild_index: true,
-          min_search_length: 2,
           separator: '[\\s\\-\\.]+',
         },
       },
@@ -49,6 +50,12 @@
     markdown_extensions: [
       'pymdownx.highlight',
       'pymdownx.superfences',
+      {
+        mdx_truly_sane_lists: {
+          nested_indent: 2,
+          truly_sane: true,
+        },
+      },
     ],
   },
 


### PR DESCRIPTION
This ports back the improvements introduced in Grafonnet, this layout
seems to work well.

### Versions move into the header navigation
![k8s-example2](https://github.com/jsonnet-libs/k8s/assets/3349855/22870634-f613-44de-aa51-b669dd03ab10)

### Index gets properly indented
![k8s-example3](https://github.com/jsonnet-libs/k8s/assets/3349855/066f7705-7400-4c52-b671-4cca8f96c65e)

### Hide unnecessary headers
![k8s-example1](https://github.com/jsonnet-libs/k8s/assets/3349855/0eec00e6-392d-46a9-a1ec-a5377778f0c4)
