### PR TITLE
Fix: add missing comma  and let the CNPG v1.23.1 to be built

### DIFF
--- a/libs/cloudnative-pg/config.jsonnet
+++ b/libs/cloudnative-pg/config.jsonnet
@@ -3,7 +3,7 @@
 local config = import 'jsonnet/config.jsonnet';
 
 local versions = [
-  { version: '1.23.1' }   // released on April 30, 2024
+  { version: '1.23.1' },  // released on April 30, 2024
   { version: '1.22.3' },  // released on April 24, 2024
   { version: '1.21.5' },  // released on April 24, 2024
 ];

--- a/libs/cloudnative-pg/config.jsonnet
+++ b/libs/cloudnative-pg/config.jsonnet
@@ -3,9 +3,9 @@
 local config = import 'jsonnet/config.jsonnet';
 
 local versions = [
-  { version: '1.22.0' }, // released on December 21, 2023
-  { version: '1.21.2' }, // released on December 21, 2023
-  { version: '1.20.5' }, // released on November 3, 2023
+  { version: '1.22.1' }, // released on February 2, 2024
+  { version: '1.21.3' }, // released on February 2, 2024
+  { version: '1.20.6' }, // released on February 2, 2024
 ];
 
 config.new(


### PR DESCRIPTION
It should fix the issue with building the latest CNPG version.