### PR TITLE
Add contour-gateway

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -771,6 +771,46 @@
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
       "if": "steps.filter.outputs.workflows == 'true'"
       "run": "make libs/contour"
+  "contour-gateway":
+    "name": "Generate contour-gateway Jsonnet library and docs"
+    "needs":
+    - "build"
+    - "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v3"
+    - "id": "filter"
+      "uses": "dorny/paths-filter@v2"
+      "with":
+        "filters": |
+          workflows:
+            - '.github/**'
+            - 'bin/**'
+            - 'Dockerfile'
+            - 'go.mod'
+            - 'go.sum'
+            - 'jsonnet/**'
+            - 'main.go'
+            - 'Makefile'
+            - 'pkg/**'
+            - 'scripts/**'
+            - 'tf/**'
+            - 'libs/contour-gateway/**'
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "uses": "actions/download-artifact@v2"
+      "with":
+        "name": "docker-artifact"
+        "path": "artifacts"
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make load"
+    - "env":
+        "DIFF": "true"
+        "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+        "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
+        "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
+        "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
+      "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make libs/contour-gateway"
   "crossplane":
     "name": "Generate crossplane Jsonnet library and docs"
     "needs":
@@ -2197,6 +2237,7 @@
     - "composable"
     - "consul"
     - "contour"
+    - "contour-gateway"
     - "crossplane"
     - "datadog-operator"
     - "eck-operator"

--- a/libs/contour-gateway/config.jsonnet
+++ b/libs/contour-gateway/config.jsonnet
@@ -1,0 +1,20 @@
+local config = import 'jsonnet/config.jsonnet';
+local versions = [
+  { version: '1.29', tag: 'v1.29.1'},
+  { version: '1.28', tag: 'v1.28.5'}, // Contour v1.28+ fully supports Gateway API v1.0.0
+];
+
+config.new(
+  name='contour-gateway',
+  specs=[
+    {
+      output: v.version,
+      prefix: '^io\\.k8s\\.networking\\..*',
+      crds: [
+        'https://raw.githubusercontent.com/projectcontour/contour/%(tag)s/examples/gateway/00-crds.yaml' % v,
+      ],
+      localName: 'contour-gateway',
+    }
+    for v in versions
+  ]
+)

--- a/libs/vault-secrets-operator/config.jsonnet
+++ b/libs/vault-secrets-operator/config.jsonnet
@@ -3,7 +3,10 @@ local config = import 'jsonnet/config.jsonnet';
 local versions = [
   { version: '0.1.0' },
   { version: '0.2.0' },
-  { version: '0.3.0' },
+  { version: '0.4.0' },
+  { version: '0.5.0' },
+  { version: '0.6.0' },
+  { version: '0.7.0' },
 ];
 
 config.new(


### PR DESCRIPTION
This adds the Contour gateway CRDs.

https://projectcontour.io/docs/main/config/gateway-api/

Since Contour [1.28+](https://projectcontour.io/resources/compatibility-matrix/) it supports the [Gateway API](https://gateway-api.sigs.k8s.io/) v1.0.0.