### PR TITLE
Add minio-operator 6.0.0, fix prefix

### DIFF
--- a/libs/minio-operator/config.jsonnet
+++ b/libs/minio-operator/config.jsonnet
@@ -1,10 +1,11 @@
 local config = import 'jsonnet/config.jsonnet';
 local versions = [
-   'v5.0.15',
-   'v5.0.14',
-   'v5.0.13',
-   'v5.0.12',
-   'v5.0.11'
+  'v6.0.0',
+  'v5.0.15',
+  'v5.0.14',
+  'v5.0.13',
+  'v5.0.12',
+  'v5.0.11'
 ];
 
 config.new(
@@ -12,11 +13,11 @@ config.new(
   specs=[
     {
       output: v,
-      prefix: '^com\\.authzed\\..*',
+      prefix: '^io\\.min\\..*',
       crds: [
-	'https://raw.githubusercontent.com/minio/operator/%s/resources/base/crds/job.min.io_miniojobs.yaml' % v,
-	'https://raw.githubusercontent.com/minio/operator/%s/resources/base/crds/minio.min.io_tenants.yaml' % v,
-	'https://raw.githubusercontent.com/minio/operator/%s/resources/base/crds/sts.min.io_policybindings.yaml.yaml' % v,
+        'https://raw.githubusercontent.com/minio/operator/%s/resources/base/crds/job.min.io_miniojobs.yaml' % v,
+        'https://raw.githubusercontent.com/minio/operator/%s/resources/base/crds/minio.min.io_tenants.yaml' % v,
+        'https://raw.githubusercontent.com/minio/operator/%s/resources/base/crds/sts.min.io_policybindings.yaml.yaml' % v,
       ],
       localName: 'minio-operator',
     }


### PR DESCRIPTION
Looks like a copy-paste error for the prefix.

Also added v6.0.0 and corrected inconsistent spacing.