### PR TITLE
feat: Add k8s gateway api v1.1 and all experimental versions

### DIFF
--- a/libs/gateway-api/config.jsonnet
+++ b/libs/gateway-api/config.jsonnet
@@ -4,6 +4,7 @@ local versions = [
     {output: '0.7', version: '0.7.1'},
     {output: '0.8', version: '0.8.1'},
     {output: '1.0', version: '1.0.0'},
+    {output: '1.1', version: '1.1.0'},
 ];
 
 config.new(
@@ -14,6 +15,16 @@ config.new(
       prefix: '^io\\.k8s\\.networking\\.gateway\\..*',
 	    crds: [
         'https://github.com/kubernetes-sigs/gateway-api/releases/download/v%(version)s/standard-install.yaml' % { version: v.version }
+      ],
+      localName: 'gateway-api',
+    }
+    for v in versions
+  ] + [
+    {
+      output: v.output + "-experimental",
+      prefix: '^io\\.k8s\\.networking\\.gateway\\..*',
+      crds: [
+        'https://github.com/kubernetes-sigs/gateway-api/releases/download/v%(version)s/experimental-install.yaml' % { version: v.version }
       ],
       localName: 'gateway-api',
     }


### PR DESCRIPTION
### Context

A new version of the Kubernetes Gateway API has been released (v1.1.0).

Also, it has been noted that [experimental versions](https://gateway-api.sigs.k8s.io/concepts/versioning/) of the API have not been included in the jsonnet-libs releases up until now.

### Intent

1. Add support for v1.1.0
2. Add experimental release for all existing versions up to and including the latest v1.1.0