### PR TITLE
feat(tektoncd): add tektoncd lib

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2276,6 +2276,7 @@
     - "securecodebox"
     - "spicedb-operator"
     - "strimzi"
+    - "tektoncd"
     - "teleport-operator"
     - "traefik"
     - "triggermesh"
@@ -2476,6 +2477,46 @@
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
       "if": "steps.filter.outputs.workflows == 'true'"
       "run": "make libs/strimzi"
+  "tektoncd":
+    "name": "Generate tektoncd Jsonnet library and docs"
+    "needs":
+    - "build"
+    - "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v3"
+    - "id": "filter"
+      "uses": "dorny/paths-filter@v2"
+      "with":
+        "filters": |
+          workflows:
+            - '.github/**'
+            - 'bin/**'
+            - 'Dockerfile'
+            - 'go.mod'
+            - 'go.sum'
+            - 'jsonnet/**'
+            - 'main.go'
+            - 'Makefile'
+            - 'pkg/**'
+            - 'scripts/**'
+            - 'tf/**'
+            - 'libs/tektoncd/**'
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "uses": "actions/download-artifact@v2"
+      "with":
+        "name": "docker-artifact"
+        "path": "artifacts"
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make load"
+    - "env":
+        "DIFF": "true"
+        "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+        "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
+        "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
+        "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
+      "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make libs/tektoncd"
   "teleport-operator":
     "name": "Generate teleport-operator Jsonnet library and docs"
     "needs":

--- a/libs/tektoncd/config.jsonnet
+++ b/libs/tektoncd/config.jsonnet
@@ -1,0 +1,31 @@
+local config = import 'jsonnet/config.jsonnet';
+
+local urlTemplate = 'https://raw.githubusercontent.com/tektoncd/pipeline/v%(version)s/config/300-crds/300-%(crd)s.yaml';
+local crds = [
+  'clustertask',
+  'customrun',
+  'pipeline',
+  'pipelinerun',
+  'resolutionrequest',
+  'task',
+  'taskrun',
+  'verificationpolicy',
+];
+
+local versions = ['0.62.1'];
+
+config.new(
+  name='tektoncd',
+  specs=[
+    {
+      output: version,
+      prefix: '^dev\\.tekton.*',
+      crds: [
+        urlTemplate % { crd: crd, version: version }
+        for crd in crds
+        ],
+      localName: 'tektoncd',
+    }
+    for version in versions
+  ]
+)


### PR DESCRIPTION
Add tektoncd.


---
> Note: I faced the error `ERROR: unrecognized argument: -c` when first running `make configure`. That was because the `jsonnet` command I had installed was not [`go-jsonnet`](https://github.com/google/go-jsonnet).
> In my case `brew uninstall jsonnet && brew install go-jsonnet` solved the issue.