### PR TITLE
feat: datadog-operator v1.8.0 with DatadogPodAutoscaler CRD

### DIFF
--- a/libs/datadog-operator/config.jsonnet
+++ b/libs/datadog-operator/config.jsonnet
@@ -3,6 +3,7 @@ local config = import 'jsonnet/config.jsonnet';
 local versions = [
   { version: '1.6.0', tag: 'v1.6.0' },
   { version: '1.7.0', tag: 'v1.7.0' },
+  { version: '1.8.0', tag: 'v1.8.0' },
 ];
 
 config.new(
@@ -17,6 +18,7 @@ config.new(
         'https://raw.githubusercontent.com/DataDog/datadog-operator/%s/config/crd/bases/v1/datadoghq.com_datadogmetrics.yaml' % [v.tag],
         'https://raw.githubusercontent.com/DataDog/datadog-operator/%s/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml' % [v.tag],
         'https://raw.githubusercontent.com/DataDog/datadog-operator/%s/config/crd/bases/v1/datadoghq.com_datadogslos.yaml' % [v.tag],
+        'https://raw.githubusercontent.com/DataDog/datadog-operator/%s/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml' % [v.tag],  // new in v1.8.0 but we can do it this lazy way because the k8s build will silently succeed regardless of remote http code
       ],
       localName: 'datadog-operator',
     }


### PR DESCRIPTION
Simple version bump to v1.8.0 released CRDs.