### PR TITLE
Bump Upbound Provider AWS to v1.6.1

### DIFF
--- a/libs/crossplane/config.jsonnet
+++ b/libs/crossplane/config.jsonnet
@@ -88,9 +88,9 @@ config.new(
     // Upbound official providers
     // https://marketplace.upbound.io/
     {
-      output: 'upbound-provider-aws/0.40',
+      output: 'upbound-provider-aws/1.6.1',
       prefix: '^io\\.upbound\\.aws\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-aws@v0.40.0'],
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-upjet-aws@v1.6.1'],
       localName: 'upbound_aws',
     },
     {

--- a/libs/crossplane/config.jsonnet
+++ b/libs/crossplane/config.jsonnet
@@ -88,7 +88,7 @@ config.new(
     // Upbound official providers
     // https://marketplace.upbound.io/
     {
-      output: 'upbound-provider-aws/1.6.1',
+      output: 'upbound-provider-aws/1.6.0',
       prefix: '^io\\.upbound\\.aws\\..*',
       crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-upjet-aws@v1.6.0'],
       localName: 'upbound_aws',

--- a/libs/crossplane/config.jsonnet
+++ b/libs/crossplane/config.jsonnet
@@ -90,7 +90,7 @@ config.new(
     {
       output: 'upbound-provider-aws/1.6.1',
       prefix: '^io\\.upbound\\.aws\\..*',
-      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-upjet-aws@v1.6.1'],
+      crds: ['https://doc.crds.dev/raw/github.com/crossplane-contrib/provider-upjet-aws@v1.6.0'],
       localName: 'upbound_aws',
     },
     {


### PR DESCRIPTION
Bump Upbound Provider AWS to v1.6.1
This PR should add v1beta2 CRDs

URL validation: https://doc.crds.dev/github.com/crossplane-contrib/provider-upjet-aws@v1.6.1