### PR TITLE
feat: datadog-operator v1.9.0 with DatadogDashboards CRD

### DIFF
--- a/libs/datadog-operator/config.jsonnet
+++ b/libs/datadog-operator/config.jsonnet
@@ -20,6 +20,8 @@ config.new(
         'https://raw.githubusercontent.com/DataDog/datadog-operator/%s/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml' % [v.tag],
         'https://raw.githubusercontent.com/DataDog/datadog-operator/%s/config/crd/bases/v1/datadoghq.com_datadogslos.yaml' % [v.tag],
         'https://raw.githubusercontent.com/DataDog/datadog-operator/%s/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml' % [v.tag],  // new in v1.8.0 but we can do it this lazy way because the k8s build will silently succeed regardless of remote http code
+        'https://raw.githubusercontent.com/DataDog/datadog-operator/%s/config/crd/bases/v1/datadoghq.com_datadogdashboards.yaml' % [v.tag], 
+      
       ],
       localName: 'datadog-operator',
     }

--- a/libs/datadog-operator/config.jsonnet
+++ b/libs/datadog-operator/config.jsonnet
@@ -4,6 +4,7 @@ local versions = [
   { version: '1.6.0', tag: 'v1.6.0' },
   { version: '1.7.0', tag: 'v1.7.0' },
   { version: '1.8.0', tag: 'v1.8.0' },
+  { version: '1.9.0', tag: 'v1.9.0' },
 ];
 
 config.new(


### PR DESCRIPTION
Version bump to v1.9.0 released CRDs.