### PR TITLE
Add new prometheus-operator versions

### DIFF
--- a/libs/prometheus-operator/config.jsonnet
+++ b/libs/prometheus-operator/config.jsonnet
@@ -1,16 +1,6 @@
 local config = import 'jsonnet/config.jsonnet';
 
 local versions = [
-  { output: '0.57', version: '0.57.0' },
-  { output: '0.58', version: '0.58.0' },
-  { output: '0.59', version: '0.59.2' },
-  { output: '0.60', version: '0.60.0' },
-  { output: '0.61', version: '0.61.1' },
-  { output: '0.62', version: '0.62.0' },
-  { output: '0.63', version: '0.63.0' },
-  { output: '0.64', version: '0.64.1' },
-  { output: '0.65', version: '0.65.2' },
-  { output: '0.66', version: '0.66.0' },
   { output: '0.67', version: '0.67.1' },
   { output: '0.68', version: '0.68.0' },
   { output: '0.69', version: '0.69.1' },


### PR DESCRIPTION
Add new Prometheus-operator versions. See the available [releases](https://github.com/prometheus-operator/prometheus-operator/releases).