### PR TITLE
Fix Upbound CRD generation Makefile

### DIFF
--- a/libs/crossplane/Makefile
+++ b/libs/crossplane/Makefile
@@ -22,7 +22,7 @@ GCP_VERSION?=v1.8.3
 upbound_gcp_crds.libsonnet:
 	cd $(TMP) && \
 	jb init && \
-	jb install github.com/crossplane-contrib/provider-upjet-gcp/package/crds@$(AWS_VERSION) && \
+	jb install github.com/crossplane-contrib/provider-upjet-gcp/package/crds@$(GCP_VERSION) && \
 	echo '[' > $(ROOT_DIR)/upbound_gcp_crds.libsonnet && \
 	cd vendor/github.com/crossplane-contrib/provider-upjet-gcp/package/crds && \
 	find . -type f -printf "%f\n" | sort | xargs -I {} echo "'{}'," >> $(ROOT_DIR)/upbound_gcp_crds.libsonnet && \


### PR DESCRIPTION
Fix a typo in the generation script. No-op since previously the CRD list was generated for v1.7.0 and in v1.8.3 no change happened.