### PR TITLE
Dirty-fix for known bug #307: Ignore keys containing '$'.

### DIFF
--- a/pkg/builder/objects.go
+++ b/pkg/builder/objects.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"fmt"
+	"log"
 	"strings"
 )
 
@@ -82,6 +83,7 @@ func (o ObjectType) ConciseString() string {
 
 func printChildren(children map[string]Type, order []string, s string) string {
 	j := ""
+	order = removeStringsWithDollar(order)
 	for _, name := range order {
 		c := children[name]
 		colon := ":"
@@ -118,4 +120,16 @@ func printChildren(children map[string]Type, order []string, s string) string {
 	}
 	j = strings.TrimSuffix(j, s)
 	return j
+}
+
+func removeStringsWithDollar(input []string) []string {
+	var result []string
+	for _, str := range input {
+		if !strings.Contains(str, "$") {
+			result = append(result, str)
+		} else {
+			log.Default().Printf("Warning: %s contains a '$' and has been ommited from final libsonnet as a temporary fix", str)
+		}
+	}
+	return result
 }


### PR DESCRIPTION
Here is the URL of the known bug i am referring to: [Bug-307](https://github.com/jsonnet-libs/k8s/issues/307)

I encountered the same issue when attempting to create a lib for the OpenFeatureOperators CRDs.

This is only a quick and dirty "fix". It basically just ignores the field containing the $ sign. This allows at least the rest of the libsonnet to be generated.

Additionally a message is written to the Log, informing, that certain fields have been ommited.