### PR TITLE
Add CRDs for functions patch-and-transform and cel-filter

### DIFF
--- a/libs/crossplane/config.jsonnet
+++ b/libs/crossplane/config.jsonnet
@@ -154,5 +154,17 @@ config.new(
       crds: ['https://doc.crds.dev/raw/github.com/upbound/provider-terraform@v0.16.0'],
       localName: 'upbound_terraform',
     },
+    {
+      output: 'function-patch-and-transform/0.7',
+      prefix: '^io\\.crossplane\\.fn\\.pt\\..*',
+      crds: ['https://raw.githubusercontent.com/crossplane-contrib/function-patch-and-transform/refs/tags/v0.7.0/package/input/pt.fn.crossplane.io_resources.yaml'],
+      localName: 'function_patch_and_transform'
+    },
+    {
+      output: 'function-cel-filter/0.1',
+      prefix: '^io\\.crossplane\\.fn\\.cel\\..*',
+      crds: ['https://raw.githubusercontent.com/crossplane-contrib/function-cel-filter/refs/tags/v0.1.1/package/input/cel.fn.crossplane.io_filters.yaml'],
+      localName: 'function_cel_filter'
+    }
   ]
 )


### PR DESCRIPTION
This PR adds CRDs for inputs for two crossplane functions:
- [function-patch-and-transform](https://github.com/crossplane-contrib/function-patch-and-transform)
- [function-cel-filter](https://github.com/crossplane-contrib/function-cel-filter)