### PR TITLE
Bump CNPG library to v1.25.0

### DIFF
--- a/libs/cloudnative-pg/config.jsonnet
+++ b/libs/cloudnative-pg/config.jsonnet
@@ -3,26 +3,39 @@
 local config = import 'jsonnet/config.jsonnet';
 
 local versions = [
-  { version: '1.24.1' },  // released on 16 OCT, 2024
-  { version: '1.23.5' },  // released on 16 OCT, 2024
+  { version: '1.25.0' },  // released on 23 DEC 2024
+  { version: '1.24.2' },  // released on 23 DEC 2024
+  { version: '1.23.6' },  // released on 23 DEC, 2024
 ];
 
 config.new(
   name='cloudnative-pg',
   specs=[
     {
-
       local url = 'https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/main/config/crd/bases/',
-
       output: v.version,
-      crds: [
-        '%s/postgresql.cnpg.io_backups.yaml' % url,
-        '%s/postgresql.cnpg.io_clusters.yaml' % url,
-        '%s/postgresql.cnpg.io_clusterimagecatalogs.yaml' % url,
-        '%s/postgresql.cnpg.io_imagecatalogs.yaml' % url,
-        '%s/postgresql.cnpg.io_poolers.yaml' % url,
-        '%s/postgresql.cnpg.io_scheduledbackups.yaml' % url,
-      ],
+      crds:
+        if (v.version == '1.25.0') then
+          [
+            '%s/postgresql.cnpg.io_backups.yaml' % url,
+            '%s/postgresql.cnpg.io_clusterimagecatalogs.yaml' % url,
+            '%s/postgresql.cnpg.io_clusters.yaml' % url,
+            '%s/postgresql.cnpg.io_databases.yaml' % url,  // Added in v1.25.0
+            '%s/postgresql.cnpg.io_imagecatalogs.yaml' % url,
+            '%s/postgresql.cnpg.io_poolers.yaml' % url,
+            '%s/postgresql.cnpg.io_publications.yaml' % url,  // Added in v1.25.0
+            '%s/postgresql.cnpg.io_scheduledbackups.yaml' % url,
+            '%s/postgresql.cnpg.io_subscriptions.yaml' % url,  // Added in v1.25.0
+          ]
+        else
+          [
+            '%s/postgresql.cnpg.io_backups.yaml' % url,
+            '%s/postgresql.cnpg.io_clusterimagecatalogs.yaml' % url,
+            '%s/postgresql.cnpg.io_clusters.yaml' % url,
+            '%s/postgresql.cnpg.io_imagecatalogs.yaml' % url,
+            '%s/postgresql.cnpg.io_poolers.yaml' % url,
+            '%s/postgresql.cnpg.io_scheduledbackups.yaml' % url,
+          ],
       prefix: '^io\\.cnpg\\.postgresql\\..*',
       localName: 'cloudnative-pg',
     }

--- a/libs/cloudnative-pg/config.jsonnet
+++ b/libs/cloudnative-pg/config.jsonnet
@@ -15,27 +15,23 @@ config.new(
       local url = 'https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/main/config/crd/bases/',
       output: v.version,
       crds:
-        if (v.version == '1.25.0') then
-          [
-            '%s/postgresql.cnpg.io_backups.yaml' % url,
-            '%s/postgresql.cnpg.io_clusterimagecatalogs.yaml' % url,
-            '%s/postgresql.cnpg.io_clusters.yaml' % url,
-            '%s/postgresql.cnpg.io_databases.yaml' % url,  // Added in v1.25.0
-            '%s/postgresql.cnpg.io_imagecatalogs.yaml' % url,
-            '%s/postgresql.cnpg.io_poolers.yaml' % url,
-            '%s/postgresql.cnpg.io_publications.yaml' % url,  // Added in v1.25.0
-            '%s/postgresql.cnpg.io_scheduledbackups.yaml' % url,
-            '%s/postgresql.cnpg.io_subscriptions.yaml' % url,  // Added in v1.25.0
+        [
+          '%s/postgresql.cnpg.io_backups.yaml' % url,
+          '%s/postgresql.cnpg.io_clusterimagecatalogs.yaml' % url,
+          '%s/postgresql.cnpg.io_clusters.yaml' % url,
+          '%s/postgresql.cnpg.io_imagecatalogs.yaml' % url,
+          '%s/postgresql.cnpg.io_poolers.yaml' % url,
+          '%s/postgresql.cnpg.io_scheduledbackups.yaml' % url,
+        ]
+        + (
+          if (v.version == '1.25.0')
+          then [
+            '%s/postgresql.cnpg.io_databases.yaml' % url,
+            '%s/postgresql.cnpg.io_publications.yaml' % url,
+            '%s/postgresql.cnpg.io_subscriptions.yaml' % url,
           ]
-        else
-          [
-            '%s/postgresql.cnpg.io_backups.yaml' % url,
-            '%s/postgresql.cnpg.io_clusterimagecatalogs.yaml' % url,
-            '%s/postgresql.cnpg.io_clusters.yaml' % url,
-            '%s/postgresql.cnpg.io_imagecatalogs.yaml' % url,
-            '%s/postgresql.cnpg.io_poolers.yaml' % url,
-            '%s/postgresql.cnpg.io_scheduledbackups.yaml' % url,
-          ],
+          else []
+        ),
       prefix: '^io\\.cnpg\\.postgresql\\..*',
       localName: 'cloudnative-pg',
     }


### PR DESCRIPTION
The PR adds a new version for the CloudNative-PG operator. See the [docs](https://cloudnative-pg.io/docs/). 