### PR TITLE
chore(argo-cd): reduce to supported versions

### DIFF
--- a/libs/argo-cd/config.jsonnet
+++ b/libs/argo-cd/config.jsonnet
@@ -1,6 +1,14 @@
 local config = import 'jsonnet/config.jsonnet';
-local versions = ['2.5.22', '2.6.15', '2.7.18', '2.8.21', '2.9.22', '2.10.18', '2.11.12', '2.12.8', '2.13.2'];
+local versions =
+  [
+    '2.11.12',
+    '2.12.8',
+    '2.13.2',
+  ];
 local manifests = ['application-crd.yaml', 'appproject-crd.yaml', 'applicationset-crd.yaml'];
+
+// Source: https://argo-cd.readthedocs.io/en/stable/developer-guide/release-process-and-cadence/#patch-releases-eg-25x
+assert std.length(versions) <= 3 : 'Only the three most recent minor versions are eligible for patch releases. Versions older than the three most recent minor versions are considered EOL and will not receive bug fixes or security updates.';
 
 config.new(
   name='argo-cd',


### PR DESCRIPTION
This PR reduces the number of supported argo-cd versions.

> Only the three most recent minor versions are eligible for patch releases. Versions older than the three most recent minor versions are considered EOL and will not receive bug fixes or security updates.

Source: https://argo-cd.readthedocs.io/en/stable/developer-guide/release-process-and-cadence/#patch-releases-eg-25x

