### PR TITLE
feat(strimzi): remove 0.3x versions; add versions up to 0.45

### DIFF
--- a/libs/strimzi/config.jsonnet
+++ b/libs/strimzi/config.jsonnet
@@ -1,6 +1,6 @@
 local config = import 'jsonnet/config.jsonnet';
 
-local versions = ['0.36', '0.37', '0.38', '0.39', '0.40', '0.41'];
+local versions = ['0.40', '0.41', '0.42','0.43', '0.44', '0.45'];
 
 config.new(
   name='strimzi',


### PR DESCRIPTION
solves https://github.com/jsonnet-libs/k8s/issues/521
Add support for strimzi up to v0.45 and remove support for 0.3x which has the latest release for 0.39 in 2023.