### PR TITLE
Upgrade zalando operator

### DIFF
--- a/libs/zalando-postgres-operator/config.jsonnet
+++ b/libs/zalando-postgres-operator/config.jsonnet
@@ -1,8 +1,9 @@
 local config = import 'jsonnet/config.jsonnet';
 local versions = [
-  {version: '1.8', tag: 'v1.8.2' },
-  {version: '1.7', tag: 'v1.7.1' },
-  {version: '1.6', tag: 'v1.6.3' },
+  { version: '1.14', tag: 'v1.14.0' },
+  { version: '1.13', tag: 'v1.13.0' },
+  { version: '1.12', tag: 'v1.12.2' },
+  { version: '1.11', tag: 'v1.11.0' },
 ];
 
 config.new(
@@ -12,9 +13,9 @@ config.new(
       output: v.version,
       prefix: '^do\\.zalan\\.acid\\..*',
       crds: [
-        'https://github.com/zalando/postgres-operator/raw/'+v.tag+'/charts/postgres-operator/crds/operatorconfigurations.yaml',
-        'https://github.com/zalando/postgres-operator/raw/'+v.tag+'/charts/postgres-operator/crds/postgresqls.yaml',
-        'https://github.com/zalando/postgres-operator/raw/'+v.tag+'/charts/postgres-operator/crds/postgresteams.yaml',
+        'https://github.com/zalando/postgres-operator/raw/' + v.tag + '/charts/postgres-operator/crds/operatorconfigurations.yaml',
+        'https://github.com/zalando/postgres-operator/raw/' + v.tag + '/charts/postgres-operator/crds/postgresqls.yaml',
+        'https://github.com/zalando/postgres-operator/raw/' + v.tag + '/charts/postgres-operator/crds/postgresteams.yaml',
       ],
       localName: 'zalando_postgres_operator',
     }

--- a/libs/zalando-postgres-operator/config.jsonnet
+++ b/libs/zalando-postgres-operator/config.jsonnet
@@ -4,6 +4,7 @@ local versions = [
   { version: '1.13', tag: 'v1.13.0' },
   { version: '1.12', tag: 'v1.12.2' },
   { version: '1.11', tag: 'v1.11.0' },
+  { version: '1.8', tag: 'v1.8.2' },
 ];
 
 config.new(


### PR DESCRIPTION
solves #525 

- remove all versions (>2y old), but keep v1.8 for compatibility
- add v1.11-v1.14

