### PR TITLE
istio: crd-all.gen.yaml moved from crds to files since 1.24

### DIFF
--- a/libs/istio/config.jsonnet
+++ b/libs/istio/config.jsonnet
@@ -1,13 +1,14 @@
 local config = import 'jsonnet/config.jsonnet';
 local versions = [
-  ['1.24', '1.24.0'],
-  ['1.23', '1.23.3'],
-  ['1.22', '1.22.3'],
-  ['1.21', '1.21.5'],
-  ['1.20', '1.20.0'],
-  ['1.19', '1.19.1'],
-  ['1.18', '1.18.6'],
-  ['1.17', '1.17.6'],
+  ['1.25', '1.25.2','files'],
+  ['1.24', '1.24.5','files'],
+  ['1.23', '1.23.3','crds'],
+  ['1.22', '1.22.3','crds'],
+  ['1.21', '1.21.5','crds'],
+  ['1.20', '1.20.0','crds'],
+  ['1.19', '1.19.1','crds'],
+  ['1.18', '1.18.6','crds'],
+  ['1.17', '1.17.6','crds'],
 ];
 
 config.new(
@@ -16,7 +17,7 @@ config.new(
     {
       output: version[0],
       prefix: '^io\\.istio\\..*',
-      crds: ['https://raw.githubusercontent.com/istio/istio/' + version[1] + '/manifests/charts/base/crds/crd-all.gen.yaml'],
+      crds: ['https://raw.githubusercontent.com/istio/istio/' + version[1] + '/manifests/charts/base/' + version[2] + '/crd-all.gen.yaml'],
       localName: 'istio',
       patchDir: 'custom',
     }


### PR DESCRIPTION
since istio: crd-all.gen.yaml moved from `crds` to `files` since 1.24

Before Istio 1.24, the location as below:
https://raw.githubusercontent.com/istio/istio/1.17.6/manifests/charts/base/crds/crd-all.gen.yaml
https://raw.githubusercontent.com/istio/istio/1.23.3/manifests/charts/base/crds/crd-all.gen.yaml

but moved from `crds` to `files` since 1.24
https://raw.githubusercontent.com/istio/istio/1.24.5/manifests/charts/base/files/crd-all.gen.yaml
https://raw.githubusercontent.com/istio/istio/1.25.2/manifests/charts/base/files/crd-all.gen.yaml