### PR TITLE
feat: Generate for latest CNRM version (1.130.2)

### DIFF
--- a/libs/cnrm/config.jsonnet
+++ b/libs/cnrm/config.jsonnet
@@ -4,6 +4,7 @@ local versions = [
   ['1.82', '1.82.0'],
   ['1.93', '1.93.0'],
   ['1.99', '1.99.0'],
+  ['1.130', '1.130.2'],
 ];
 
 
@@ -13,7 +14,7 @@ config.new(
     {
       output: version[0],
       prefix: '^com\\.google\\.cloud\\.cnrm\\..*',
-      crds: ['https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-config-connector/v' + version[1] +'/install-bundles/install-bundle-workload-identity/crds.yaml'],
+      crds: ['https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-config-connector/v' + version[1] + '/install-bundles/install-bundle-workload-identity/crds.yaml'],
       localName: 'cnrm',
     }
     for version in versions


### PR DESCRIPTION
Is a big jump, but at this point I don't think it matters if we don't include all or part of the versions in between.At least, whoever wants to use latest version would be able to do so.