### PR TITLE
Update go to 1.21 and pin go-jsonnet version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as base
+FROM golang:1.21 as base
 
 ENV GO111MODULE=on
 WORKDIR /app
@@ -17,10 +17,10 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
         -ldflags='-s -w -extldflags "-static"' \
         -o k8s-gen .
 
-FROM golang:1.20-alpine3.18 as jsonnet
+FROM golang:1.21-alpine3.18 as jsonnet
 
 RUN apk add --no-cache git
-RUN go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+RUN go install github.com/google/go-jsonnet/cmd/jsonnet@v0.21.0
 
 FROM alpine:3.18
 


### PR DESCRIPTION
Update go to 1.21 and pin go-jsonnet version to v.0.21.0. This change is required for make it work with the new go-jsonnet release version: https://github.com/google/go-jsonnet/releases