### PR TITLE
Bump CloudNativePG to v1.26

### DIFF
--- a/libs/cloudnative-pg/config.jsonnet
+++ b/libs/cloudnative-pg/config.jsonnet
@@ -3,9 +3,8 @@
 local config = import 'jsonnet/config.jsonnet';
 
 local versions = [
-  { version: '1.25.0' },  // released on 23 DEC 2024
-  { version: '1.24.2' },  // released on 23 DEC 2024
-  { version: '1.23.6' },  // released on 23 DEC, 2024
+  { version: '1.26.0' },  // released on 23 May 2025
+  { version: '1.25.2' },  // released on 23 May 2025
 ];
 
 config.new(


### PR DESCRIPTION
Following the release of CloudNativePG (CNPG) v1.26, which includes significant new capabilities such as in-place major upgrades, this pull request updates our Jsonnet library to integrate this new version. See [docs](https://cloudnative-pg.io/docs/).