### PR TITLE
Bump Go to v1.23 and replace deprecated `io/ioutil` package 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as base
+FROM golang:1.23 AS base
 
 ENV GO111MODULE=on
 WORKDIR /app
@@ -17,12 +17,12 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
         -ldflags='-s -w -extldflags "-static"' \
         -o k8s-gen .
 
-FROM golang:1.20-alpine3.18 as jsonnet
+FROM golang:1.23-alpine AS jsonnet
 
 RUN apk add --no-cache git
-RUN go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+RUN go install github.com/google/go-jsonnet/cmd/jsonnet@v0.21.0
 
-FROM alpine:3.18
+FROM alpine:3.20
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jsonnet-libs/k8s
 
-go 1.20
+go 1.23
 
 require (
 	github.com/fatih/camelcase v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-jsonnet v0.20.0 h1:WG4TTSARuV7bSm4PMB4ohjxe33IHT5WVTrJSU33uT4g=
 github.com/google/go-jsonnet v0.20.0/go.mod h1:VbgWF9JX7ztlv770x/TolZNGGFfiHEVx9G6ca2eUmeA=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -101,7 +100,7 @@ func hasStr(slice []string, s string) bool {
 }
 
 func loadConfig(file string) Config {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -177,7 +176,7 @@ func writeJsonnet(to, data string) error {
 		return fmt.Errorf("%s: %s", err, data)
 	}
 
-	return ioutil.WriteFile(to, []byte(s), 0644)
+	return os.WriteFile(to, []byte(s), 0644)
 }
 
 func copyDirLibsonnet(dir, to string) ([]string, error) {
@@ -199,14 +198,14 @@ func copyDirLibsonnet(dir, to string) ([]string, error) {
 	})
 
 	for _, a := range adds {
-		content, err := ioutil.ReadFile(a)
+		content, err := os.ReadFile(a)
 		if err != nil {
 			return nil, err
 		}
 
 		a = filepath.Join(to, filepath.Base(a))
 		os.MkdirAll(filepath.Dir(a), os.ModePerm)
-		if err := ioutil.WriteFile(a, content, 0644); err != nil {
+		if err := os.WriteFile(a, content, 0644); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Changes made: 
- upgraded Go from the previous version to `1.23` in Dockerfile f25d3fcf1cf03ac74b77ab45d5a1c44218e80137
- pinned Jsonnet to `v0.21.0` f25d3fcf1cf03ac74b77ab45d5a1c44218e80137

- bump Go to v1.23 bb2901c9f58d9e05aa044fa11765c2e8332769ce
- removed deprecated `io/ioutil` package and updated functions accordingly ee20f2f62b1ff5060f24bb4f340ce37c4ce6dde9