### PR TITLE
Include kubernetes v1.33

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
 FROM golang:1.20-alpine3.18 as jsonnet
 
 RUN apk add --no-cache git
-RUN go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+RUN go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
 
 FROM alpine:3.18
 

--- a/libs/k8s/config.jsonnet
+++ b/libs/k8s/config.jsonnet
@@ -1,10 +1,10 @@
 local config = import 'jsonnet/config.jsonnet';
 local versions = [
+  '1.33',
   '1.32',
   '1.31',
   '1.30',
   '1.29',
-  '1.28',
 ];
 
 config.new(


### PR DESCRIPTION
Including the latest Kubernetes version and dropping the last version.

Also pinning the `go-jsonnet` version to `v0.20.0` as the latest release requires Go 1.23 & other container upgrades that I could not test locally.