### PR TITLE
Add Flux 2.6.0/2.6.1 libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as base
+FROM golang:1.20 AS base
 
 ENV GO111MODULE=on
 WORKDIR /app
@@ -17,10 +17,10 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
         -ldflags='-s -w -extldflags "-static"' \
         -o k8s-gen .
 
-FROM golang:1.20-alpine3.18 as jsonnet
+FROM golang:1.20-alpine3.18 AS jsonnet
 
 RUN apk add --no-cache git
-RUN go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+RUN go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
 
 FROM alpine:3.18
 

--- a/libs/fluxcd/config.jsonnet
+++ b/libs/fluxcd/config.jsonnet
@@ -4,6 +4,34 @@ config.new(
   name='fluxcd',
   specs=[
     {
+      // CRDs retrieved from https://github.com/fluxcd/flux2/blob/v2.6.1/manifests/crds/kustomization.yaml
+      output: '2.6.1',
+      prefix: '^io\\.fluxcd\\.toolkit\\..*',
+      crds: [
+        'https://github.com/fluxcd/source-controller/releases/download/v1.6.0/source-controller.crds.yaml',
+        'https://github.com/fluxcd/kustomize-controller/releases/download/v1.6.0/kustomize-controller.crds.yaml',
+        'https://github.com/fluxcd/helm-controller/releases/download/v1.3.0/helm-controller.crds.yaml',
+        'https://github.com/fluxcd/notification-controller/releases/download/v1.6.0/notification-controller.crds.yaml',
+        'https://github.com/fluxcd/image-reflector-controller/releases/download/v0.35.1/image-reflector-controller.crds.yaml',
+        'https://github.com/fluxcd/image-automation-controller/releases/download/v0.41.0/image-automation-controller.crds.yaml',
+      ],
+      localName: 'fluxcd',
+    },
+    {
+      // CRDs retrieved from https://github.com/fluxcd/flux2/blob/v2.6.0/manifests/crds/kustomization.yaml
+      output: '2.6.0',
+      prefix: '^io\\.fluxcd\\.toolkit\\..*',
+      crds: [
+        'https://github.com/fluxcd/source-controller/releases/download/v1.6.0/source-controller.crds.yaml',
+        'https://github.com/fluxcd/kustomize-controller/releases/download/v1.6.0/kustomize-controller.crds.yaml',
+        'https://github.com/fluxcd/helm-controller/releases/download/v1.3.0/helm-controller.crds.yaml',
+        'https://github.com/fluxcd/notification-controller/releases/download/v1.6.0/notification-controller.crds.yaml',
+        'https://github.com/fluxcd/image-reflector-controller/releases/download/v0.35.0/image-reflector-controller.crds.yaml',
+        'https://github.com/fluxcd/image-automation-controller/releases/download/v0.41.0/image-automation-controller.crds.yaml',
+      ],
+      localName: 'fluxcd',
+    },
+    {
       // CRDs retrieved from https://github.com/fluxcd/flux2/blob/v2.5.1/manifests/crds/kustomization.yaml
       output: '2.5.1',
       prefix: '^io\\.fluxcd\\.toolkit\\..*',


### PR DESCRIPTION
Had to pin go-jsonnet to 0.20.0 while current PRs upgrading to go 1.21/1.23 and go-jsonnet 0.21.0 are merged