### PR TITLE
external-secrets: Include v0.16, v0.17, and v0.18

### DIFF
--- a/libs/external-secrets/config.jsonnet
+++ b/libs/external-secrets/config.jsonnet
@@ -26,6 +26,9 @@ local versions = [
   version('0.8', '0.8.12'),
   version('0.9', '0.9.12'),
   version('0.15', '0.15.1'),
+  version('0.16', '0.16.2'),
+  version('0.17', '0.17.0'),
+  version('0.18', '0.18.2'),
 ];
 
 config.new(


### PR DESCRIPTION
This updates the available versions for external-secrets to include the most recent versions.

I'm currently using v0.18.2 from this fork: https://github.com/nlowe/external-secrets-libsonnet/tree/feat/bump-to-v0.18.2