### PR TITLE
Include 1.33 in k8s libs versions

### DIFF
--- a/libs/k8s/config.jsonnet
+++ b/libs/k8s/config.jsonnet
@@ -1,5 +1,6 @@
 local config = import 'jsonnet/config.jsonnet';
 local versions = [
+  '1.33',
   '1.32',
   '1.31',
   '1.30',


### PR DESCRIPTION
Here we include the `1.33` k8s version in an attempt to generate the k8s library.