### PR TITLE
external-secrets: remove before 0.15 and add up to 0.19.2

### DIFF
--- a/libs/external-secrets/config.jsonnet
+++ b/libs/external-secrets/config.jsonnet
@@ -4,7 +4,7 @@ local
   version(
     output,
     version,
-    crdFiles=['bundle.yaml'] // from v0.5 onward, a single bundle.yaml contains all of the external-secrets CRDs.
+    crdFiles=['bundle.yaml']
   ) =
     {
       output: output,
@@ -13,19 +13,11 @@ local
     };
 
 local versions = [
-  version('0.4', '0.4.4', crdFiles=[
-    // 0.4.4 is the last version with individual CRD files
-    'external-secrets.io_clustersecretstores.yaml',
-    'external-secrets.io_externalsecrets.yaml',
-    'external-secrets.io_secretstores.yaml',
-  ]),
-  version('0.5', '0.5.9'),
-  version('0.6', '0.6.1'),
-   // From v0.7, the upstream kustomization.yaml was actually not properly containing all CRDs, we parse the bundle.yaml instead across the board for now.
-  version('0.7', '0.7.3'),
-  version('0.8', '0.8.12'),
-  version('0.9', '0.9.12'),
   version('0.15', '0.15.1'),
+  version('0.16', '0.16.2'),
+  version('0.17', '0.17.0'),
+  version('0.18', '0.18.2'),
+  version('0.19', '0.19.2'),
 ];
 
 config.new(


### PR DESCRIPTION
Updates external-secrets to include up to the latest version 0.19.2 and removes old versions in accordance with [this comment](https://github.com/jsonnet-libs/k8s/pull/555#pullrequestreview-3060833280) as that may have been blocking merge.