### PR TITLE
litmus-chaos: update to latest version & introduce chaosscheduler_crd..yaml

### DIFF
--- a/libs/litmus-chaos/config.jsonnet
+++ b/libs/litmus-chaos/config.jsonnet
@@ -1,15 +1,19 @@
 # libs/<name>/config.jsonnet
 local config = (import 'jsonnet/config.jsonnet');
 local versions = ['2.8.0', '2.9.0', '2.10.0'];
-local crdFiles = ['chaosengine_crd.yaml','chaosexperiment_crd.yaml','chaosresults_crd.yaml'];
+local crdFilesOperator = ['chaosengine_crd.yaml','chaosexperiment_crd.yaml','chaosresults_crd.yaml'];
+local crdFilesScheduler = ['chaosschedule_crd.yaml'];
 
 config.new(
   name='litmus-chaos',
   specs=[
     {
-      local baseUrl = 'https://raw.githubusercontent.com/litmuschaos/chaos-operator/%s/deploy/crds' % version,
+      local baseUrlOperator = 'https://raw.githubusercontent.com/litmuschaos/chaos-operator/%s/deploy/crds' % version,
+      local baseUrlScheduler = 'https://raw.githubusercontent.com/litmuschaos/chaos-scheduler/%s/deploy/crds' % version,
       output: version,
-      crds: [ '%s/%s' % [baseUrl, crd] for crd in crdFiles],
+      crds:
+      [ '%s/%s' % [baseUrlOperator, crd] for crd in crdFilesOperator] +
+      [ '%s/%s' % [baseUrlScheduler, crd] for crd in crdFilesScheduler],
       prefix: '^io\\.litmuschaos\\..*',
       localName: 'litmus-chaos',
     } 


### PR DESCRIPTION
Extend `litmus-chaos` functionality to support chaos_scheduler crd that is needed to create scheduled chaos tests. https://github.com/litmuschaos/chaos-scheduler/tree/master/deploy/crds