### PR TITLE
litmus-chaos: bump version to 3.20.0

### DIFF
--- a/libs/litmus-chaos/config.jsonnet
+++ b/libs/litmus-chaos/config.jsonnet
@@ -1,6 +1,6 @@
 # libs/<name>/config.jsonnet
 local config = (import 'jsonnet/config.jsonnet');
-local versions = ['2.8.0', '2.9.0', '2.10.0'];
+local versions = ['2.8.0', '2.9.0', '2.10.0', '3.20.0'];
 local crdFilesOperator = ['chaosengine_crd.yaml','chaosexperiment_crd.yaml','chaosresults_crd.yaml'];
 local crdFilesScheduler = ['chaosschedule_crd.yaml'];
 


### PR DESCRIPTION
Use latest version for:
- chaos-operator  crds: https://github.com/litmuschaos/chaos-operator/releases/tag/3.20.0
- chaos-scheduler crd : https://github.com/litmuschaos/chaos-scheduler/releases/tag/3.20.0