### PR TITLE
feat: Add node-feature-discovery CRDs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2819,6 +2819,46 @@
         "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
       "if": "steps.filter.outputs.workflows == 'true'"
       "run": "make libs/nats"
+  "node-feature-discovery":
+    "name": "Generate node-feature-discovery Jsonnet library and docs"
+    "needs":
+    - "build"
+    - "repos"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "uses": "actions/checkout@v4"
+    - "id": "filter"
+      "uses": "dorny/paths-filter@v3"
+      "with":
+        "filters": |
+          workflows:
+            - '.github/**'
+            - 'bin/**'
+            - 'Dockerfile'
+            - 'go.mod'
+            - 'go.sum'
+            - 'jsonnet/**'
+            - 'main.go'
+            - 'Makefile'
+            - 'pkg/**'
+            - 'scripts/**'
+            - 'tf/**'
+            - 'libs/node-feature-discovery/**'
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "uses": "actions/download-artifact@v4"
+      "with":
+        "name": "docker-artifact"
+        "path": "artifacts"
+    - "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make load"
+    - "env":
+        "DIFF": "true"
+        "GEN_COMMIT": "${{ github.ref == 'refs/heads/master' && github.repository == 'jsonnet-libs/k8s' }}"
+        "GIT_COMMITTER_EMAIL": "86770550+jsonnet-libs-bot@users.noreply.github.com"
+        "GIT_COMMITTER_NAME": "jsonnet-libs-bot"
+        "SSH_KEY": "${{ secrets.DEPLOY_KEY }}"
+      "if": "steps.filter.outputs.workflows == 'true'"
+      "run": "make libs/node-feature-discovery"
   "openshift":
     "name": "Generate openshift Jsonnet library and docs"
     "needs":
@@ -3128,6 +3168,7 @@
     - "minio-operator"
     - "mysql-operator"
     - "nats"
+    - "node-feature-discovery"
     - "openshift"
     - "prometheus-operator"
     - "pyrra"

--- a/libs/node-feature-discovery/config.jsonnet
+++ b/libs/node-feature-discovery/config.jsonnet
@@ -1,0 +1,21 @@
+local config = import 'jsonnet/config.jsonnet';
+
+local versions = [
+  { version: '0.15', tag: 'v0.15.7' },
+  { version: '0.16', tag: 'v0.16.9' },
+  { version: '0.17', tag: 'v0.17.4' },
+  { version: '0.18', tag: 'v0.18.3' },
+];
+
+config.new(
+  name='node-feature-discovery',
+  specs=[
+    {
+      output: v.version,
+      prefix: '^io\\.k8s-sigs\\.nfd\\..*',
+      crds: ['https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/refs/tags/%s/deployment/base/nfd-crds/nfd-api-crds.yaml' % v.tag],
+      localName: 'node-feature-discovery',
+    }
+    for v in versions
+  ]
+)


### PR DESCRIPTION
This PR adds support for `node-feature-discovery`- a tool that can be used in Kubernetes clusters to detect hardware features of nodes, such as GPUs.