### PR TITLE
feat: Support multiple container runtimes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /app
 
 RUN apk add --no-cache bash curl git openssh diffutils
 
-COPY --from=mikefarah/yq:4.34.1 /usr/bin/yq /usr/local/bin/yq2
+COPY --from=docker.io/mikefarah/yq:4.34.1 /usr/bin/yq /usr/local/bin/yq2
 COPY --from=ghcr.io/jsonnet-libs/docsonnet:0.0.5 /usr/bin/docsonnet /usr/local/bin/
 COPY --from=builder /app/k8s-gen /usr/local/bin/
 COPY --from=jsonnet /go/bin/jsonnet /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+RUNTIME ?= docker
+
 IMAGE_NAME ?= k8s-gen
 IMAGE_PREFIX ?= ghcr.io/jsonnet-libs
 IMAGE_TAG ?= 0.0.8
@@ -67,19 +69,19 @@ libs/*:
 		$(IMAGE_PREFIX)/$(IMAGE_NAME):$(IMAGE_TAG) /config /output
 
 build:
-	docker build -t $(IMAGE_PREFIX)/$(IMAGE_NAME):$(IMAGE_TAG) .
+	$(RUNTIME) build -t $(IMAGE_PREFIX)/$(IMAGE_NAME):$(IMAGE_TAG) .
 
 save:
 	mkdir -p artifacts
-	docker save $(IMAGE_PREFIX)/$(IMAGE_NAME):$(IMAGE_TAG) > artifacts/docker-image.tar
+	$(RUNTIME) save $(IMAGE_PREFIX)/$(IMAGE_NAME):$(IMAGE_TAG) > artifacts/docker-image.tar
 
 load:
-	docker load < artifacts/docker-image.tar
+	$(RUNTIME) load < artifacts/docker-image.tar
 
 push: build push-image
 
 push-image:
-	docker push $(IMAGE_PREFIX)/$(IMAGE_NAME):$(IMAGE_TAG)
-	docker push $(IMAGE_PREFIX)/$(IMAGE_NAME):latest
+	$(RUNTIME) push $(IMAGE_PREFIX)/$(IMAGE_NAME):$(IMAGE_TAG)
+	$(RUNTIME) push $(IMAGE_PREFIX)/$(IMAGE_NAME):latest
 
 .PHONY: clean configure update_objectmeta debug run all libs/* build push push-image

--- a/bin/docker.sh
+++ b/bin/docker.sh
@@ -2,12 +2,13 @@
 set -euo pipefail
 set -x
 
+RUNTIME=${RUNTIME:-docker}
 CI=${CI:-false}
 DEBUG=${DEBUG:-false}
 
 OPTS=""
-if [ "$CI" != "true" ]; then
-    # When run locally volume mounts match ownership of current user.
+if [ "$CI" != "true" ] && [ "$RUNTIME" != 'podman' ]; then
+    # When run locally (not in podman) volume mounts match ownership of current user.
     OPTS="$OPTS --user $(id -u):$(id -g)"
     OPTS="$OPTS -v /etc/passwd:/etc/passwd:ro"
     OPTS="$OPTS -v /etc/group:/etc/group:ro"
@@ -18,4 +19,4 @@ if [ "$DEBUG" == "true" ]; then
     OPTS="$OPTS -ti --entrypoint /bin/bash"
 fi
 
-docker run --rm $OPTS "$@"
+$RUNTIME run --rm $OPTS "$@"


### PR DESCRIPTION
This PR closes #618 and adds functionality to the existing build scripts to support building via other container runtimes, namely podman.

In podman, the container will run as root, as this will be remapped by the kernel thanks to namespacing arguments, and is required to properly access host files not owned by the container. I'm not 100% certain if other alternative container runtimes support this feature, so I'm leaving it as a podman-only override for now.

To run any make command using podman, you can run `make -e RUNTIME=podman`.