### PR TITLE
fix(crossplane-provider-grafana): include observe resources in generator

### DIFF
--- a/libs/crossplane-provider-grafana/config.jsonnet
+++ b/libs/crossplane-provider-grafana/config.jsonnet
@@ -8,6 +8,12 @@ config.new(
   name='crossplane-provider-grafana',
   specs=[
     {
+      output: 'crossplane-provider-grafana/observe',
+      prefix: '^io\\.crossplane\\.o\\.grafana\\..*',
+      crds: ['https://raw.githubusercontent.com/grafana/crossplane-provider-grafana/%s/package/crds/%s' % [version, crd] for crd in crds],
+      localName: 'grafana',
+    },
+    {
       output: 'crossplane-provider-grafana/namespaced',
       prefix: '^io\\.crossplane\\.m\\.grafana\\..*',
       crds: ['https://raw.githubusercontent.com/grafana/crossplane-provider-grafana/%s/package/crds/%s' % [version, crd] for crd in crds],


### PR DESCRIPTION
Also actually generate a library for the observe only resources.
