### PR TITLE
[envoy-gateway]: add back old versions

### DIFF
--- a/libs/envoy-gateway/config.jsonnet
+++ b/libs/envoy-gateway/config.jsonnet
@@ -1,7 +1,10 @@
 local config = import 'jsonnet/config.jsonnet';
 local versions = [
+  'v1.5.0',
   'v1.5.9',
+  'v1.6.0',
   'v1.6.5',
+  'v1.7.0',
   'v1.7.1',
 ];
 


### PR DESCRIPTION
In #631 , the old versions were removed which people depend on until they upgrade. We should keep all the versions until the version is deprecated. So only 1.4.x should have been removed.