### PR TITLE
Format custom patches in generator

### DIFF
--- a/libs/k8s/custom/core/autoscaling.libsonnet
+++ b/libs/k8s/custom/core/autoscaling.libsonnet
@@ -5,7 +5,6 @@ local withApiVersion = {
   withApiVersion(apiversion): { apiVersion: apiversion },
 };
 
-
 local withScaleTargetRef = {
   '#withScaleTargetRef':: d.fn(help='Set spec.ScaleTargetRef to `object`', args=[d.arg(name='object', type=d.T.object)]),
   withScaleTargetRef(object):

--- a/libs/k8s/custom/core/core.libsonnet
+++ b/libs/k8s/custom/core/core.libsonnet
@@ -39,7 +39,8 @@ local d = import 'doc-util/main.libsonnet';
             for envvar in env
           ]),
 
-        '#withEnvMap': d.fn(|||
+        '#withEnvMap': d.fn(
+          |||
 
             `withEnvMap` works like `withEnvMixin` but accepts a key/value map,
             this map is converted a list of core.v1.envVar(key, value)`.
@@ -234,19 +235,19 @@ local d = import 'doc-util/main.libsonnet';
         ]),
         fromSecret(name, secretName)::
           super.withName(name) + super.secret.withSecretName(secretName),
-        
+
         '#fromCsi': d.fn('Creates a new volume of type `csi`', [
           d.arg('name', d.T.string),
           d.arg('driver', d.T.string),
           d.arg('volumeAttributes', d.T.object, {}),
         ]),
         fromCsi(name, driver, volumeAttributes={})::
-          super.withName(name) + { 
+          super.withName(name) + {
             csi: {
               driver: driver,
               readOnly: true,
-              volumeAttributes: volumeAttributes
-            }
+              volumeAttributes: volumeAttributes,
+            },
           },
       },
 

--- a/main.go
+++ b/main.go
@@ -203,9 +203,18 @@ func copyDirLibsonnet(dir, to string) ([]string, error) {
 			return nil, err
 		}
 
+		// Run patch/extension files through the same formatter as
+		// generated files so the resulting library is consistently
+		// formatted regardless of how the source happens to be checked
+		// in. See writeJsonnet for the parallel call.
+		formatted, err := formatter.Format(a, string(content), formatter.DefaultOptions())
+		if err != nil {
+			return nil, fmt.Errorf("formatting %s: %w", a, err)
+		}
+
 		a = filepath.Join(to, filepath.Base(a))
 		os.MkdirAll(filepath.Dir(a), os.ModePerm)
-		if err := os.WriteFile(a, content, 0644); err != nil {
+		if err := os.WriteFile(a, []byte(formatted), 0644); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
`copyDirLibsonnet` copied patch files byte-for-byte into the generated repo, so any unformatted source under `libs/<lib>/custom/` leaked through. That's why `k8s-libsonnet/*/_custom/core.libsonnet` and `autoscaling.libsonnet` looked unformatted.

- `main.go`: run patches through `formatter.Format(..., DefaultOptions())`, matching `writeJsonnet`.
- `libs/k8s/custom/core/core.libsonnet`: `jsonnetfmt -i`.
- `libs/k8s/custom/core/autoscaling.libsonnet`: drop a stray double blank line.