### PR TITLE
feat(strimzi): add version 1.0.0, drop 0.49.1

### DIFF
--- a/libs/strimzi/config.jsonnet
+++ b/libs/strimzi/config.jsonnet
@@ -1,9 +1,9 @@
 local config = import 'jsonnet/config.jsonnet';
 
 local versions = [
-  '0.49.1',
   '0.50.1',
   '0.51.0',
+  '1.0.0',
 ];
 
 


### PR DESCRIPTION

- Adds Strimzi Kafka Operator v1.0.0 to the generated library
- Removes deprecated v0.49.1, keeping v0.50.1 and v0.51.0
