### PR TITLE
feat(external-secrets): bump to 0.20.4, 1.3.2, add 2.5.0

### DIFF
--- a/libs/external-secrets/config.jsonnet
+++ b/libs/external-secrets/config.jsonnet
@@ -13,9 +13,9 @@ local
     };
 
 local versions = [
-  version('0.19', '0.19.2'),
-  version('1.0', '1.0.0'),
-  version('1.1', '1.1.1'),
+  version('0.20', '0.20.4'),
+  version('1.3', '1.3.2'),
+  version('2.5', '2.5.0'),
 ];
 
 config.new(


### PR DESCRIPTION
Updates external-secrets to the 3 latest major versions.