### PR TITLE
K8s image mount

### DIFF
--- a/libs/k8s/custom/core/core.libsonnet
+++ b/libs/k8s/custom/core/core.libsonnet
@@ -249,6 +249,14 @@ local d = import 'doc-util/main.libsonnet';
               volumeAttributes: volumeAttributes,
             },
           },
+
+        '#fromImage': d.fn('Creates a new volume using a `image`', [
+          d.arg('name', d.T.string),
+          d.arg('reference', d.T.string),
+        ]),
+        fromImage(name, reference)::
+          super.withName(name) + super.image.withReference(reference),
+
       },
 
       volumeMount+:: {

--- a/libs/k8s/custom/core/core.libsonnet
+++ b/libs/k8s/custom/core/core.libsonnet
@@ -250,7 +250,7 @@ local d = import 'doc-util/main.libsonnet';
             },
           },
 
-        '#fromImage': d.fn('Creates a new volume using a `image`', [
+        '#fromImage': d.fn('Creates a new volume using an `image`', [
           d.arg('name', d.T.string),
           d.arg('reference', d.T.string),
         ]),

--- a/libs/k8s/custom/core/volumeMounts.libsonnet
+++ b/libs/k8s/custom/core/volumeMounts.libsonnet
@@ -304,6 +304,43 @@ local d = import 'doc-util/main.libsonnet';
       if std.objectHas(super.spec, 'template')
       then super.spec.template.spec.withVolumesMixin(volumeMixins)
       else super.spec.jobTemplate.spec.template.spec.withVolumesMixin(volumeMixins),
+
+    '#imageVolumeMount': d.fn(
+      |||
+        `imageVolumeMount` mounts a `image` on `path`.
+
+        If `containers` is specified as an array of container names it will only be mounted
+        to those containers, otherwise it will be mounted on all containers.
+
+        This helper function can be augmented with a `volumeMixin`. For example,
+        passing "k.core.v1.volume.image.withPullPolicy('Always')" will result in a
+        pull policy mixin.
+      |||
+      + volumeMountDescription,
+      [
+        d.arg('name', d.T.string),
+        d.arg('reference', d.T.string),
+        d.arg('path', d.T.string),
+        d.arg('volumeMountMixin', d.T.object),
+        d.arg('volumeMixin', d.T.object),
+        d.arg('containers', d.T.array),
+      ]
+    ),
+    imageVolumeMount(name, reference, path, volumeMountMixin={}, volumeMixin={}, containers=null, includeInitContainers=false)::
+      local addMount(c) = c + (
+        if containers == null || std.member(containers, c.name)
+        then container.withVolumeMountsMixin(
+          volumeMount.new(name, path) + volumeMountMixin,
+        )
+        else {}
+      );
+      local volumeMixins = [volume.fromImage(name, reference) + volumeMixin];
+
+      super.mapContainers(addMount, includeInitContainers=includeInitContainers) +
+      if std.objectHas(super.spec, 'template')
+      then super.spec.template.spec.withVolumesMixin(volumeMixins)
+      else super.spec.jobTemplate.spec.template.spec.withVolumesMixin(volumeMixins),
+
   },
 
   batch+: {


### PR DESCRIPTION
PR introduces 2 methods to ease of using the [image volumes](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/).

Example:
```jsonnet
+ deployment.imageVolumeMount('blocklists', 'bl-data:latest', '/blocklists', volumeMixin=volume.image.withPullPolicy('Always'))
```